### PR TITLE
fix: When batch uploading to Firestore, commit the courses remaining

### DIFF
--- a/functions/src/courses/Course.service.ts
+++ b/functions/src/courses/Course.service.ts
@@ -152,6 +152,8 @@ export class CoursesService {
         j = 0;
       }
     }
+    // flush remaining courses in list.
+    await commit();
   }
 }
 


### PR DESCRIPTION
## Overview
<!-- Replace `XX` with the issue # you're working on -->
Closes #175 
This PR fixes an issue where the population script (which uploads in batches of less than 450) didn't flush the courses still not yet uploaded by forgetting to flush these courses towards to the end of the array.

The example given, STAT350 and STAT254 are towards the end which is why they were never populated.

The fix is simply adding a `commit()` at the end. 
