### PR TITLE
fix: Responsive Landing Page

### DIFF
--- a/src/app/landing/index.tsx
+++ b/src/app/landing/index.tsx
@@ -34,7 +34,9 @@ export default function Landing() {
           <Flex alignItems="center" mt="1rem" as="a" w="fit-content" target="_blank" href="https://www.vikelabs.ca">
             <Text color="#4C6EA5" fontSize={{ base: '1em', md: '1.5em' }}>
               <span>{hands[handIndex]}</span> Built by students @
-              <span style={{ fontWeight: 'bolder', fontSize: '1.75em', color: '#222B49' }}> VIKE LABS</span>
+            </Text>
+            <Text fontWeight="bolder" fontSize="1.75em" color="#222B49" ml="1">
+              VIKE LABS
             </Text>
           </Flex>
         </Container>

--- a/src/app/landing/index.tsx
+++ b/src/app/landing/index.tsx
@@ -1,5 +1,5 @@
 import { Image } from '@chakra-ui/image';
-import { Flex, Grid, GridItem, Heading, Text } from '@chakra-ui/layout';
+import { Container, Flex, Grid, GridItem, Heading, Text } from '@chakra-ui/layout';
 import { useEffect, useState } from 'react';
 
 export default function Landing() {
@@ -19,32 +19,35 @@ export default function Landing() {
   return (
     <Grid
       templateColumns={{ xl: 'repeat(2, 1fr)', lg: 'repeat(1, 1fr)' }}
-      px="150px"
-      gap="81px"
-      justifyItems="center"
-      w="100%"
+      gap={2}
+      m={10}
       h="100%"
+      justifyItems="center"
       alignItems="center"
     >
-      <GridItem w={{ lg: '400px', xl: '639px', xxl: '1000px' }}>
-        <Heading fontSize="75.68px" lineHeight="100px" mb="28px">
-          Explore UVic Courses
-        </Heading>
-        <Text fontSize="25.71">CourseUp makes it simple to browse and schedule UVic Courses</Text>
-        <Flex alignItems="center" mt="40px" as="a" w="fit-content" target="_blank" href="https://www.vikelabs.ca">
-          <Text color="#4C6EA5" fontSize="24.25" mr="5px">
-            <span>{hands[handIndex]}</span> Built by students @VikeLabs
-          </Text>
-        </Flex>
+      <GridItem colSpan={1}>
+        <Container>
+          <Heading fontSize="4.75em" lineHeight="1.25" mb="1.75rem">
+            Explore UVic Courses
+          </Heading>
+          <Text fontSize="1.6em">CourseUp makes it simple to browse and schedule UVic Courses</Text>
+          <Flex alignItems="center" mt="1rem" as="a" w="fit-content" target="_blank" href="https://www.vikelabs.ca">
+            <Text color="#4C6EA5" fontSize={{ base: '1em', md: '1.5em' }}>
+              <span>{hands[handIndex]}</span> Built by students @
+              <span style={{ fontWeight: 'bolder', fontSize: '1.75em', color: '#222B49' }}> VIKE LABS</span>
+            </Text>
+          </Flex>
+        </Container>
       </GridItem>
-      <GridItem maxH="563px" minW="fit-content" display={{ base: 'none', xl: 'initial' }}>
-        <Image
-          src={process.env.PUBLIC_URL + '/assets/computer.svg'}
-          flex="1"
-          sx={{
-            filter: 'drop-shadow( 27px 8px 36px rgba(0, 0, 0, .25))',
-          }}
-        />
+      <GridItem display={{ base: 'none', xl: 'initial' }} colSpan={1}>
+        <Container>
+          <Image
+            src={process.env.PUBLIC_URL + '/assets/computer.svg'}
+            sx={{
+              filter: 'drop-shadow( 1.5rem 1rem 1.75rem rgba(0, 0, 0, .25) )',
+            }}
+          />
+        </Container>
       </GridItem>
     </Grid>
   );

--- a/src/app/landing/index.tsx
+++ b/src/app/landing/index.tsx
@@ -33,9 +33,8 @@ export default function Landing() {
         <Text fontSize="25.71">CourseUp makes it simple to browse and schedule UVic Courses</Text>
         <Flex alignItems="center" mt="40px" as="a" w="fit-content" target="_blank" href="https://www.vikelabs.ca">
           <Text color="#4C6EA5" fontSize="24.25" mr="5px">
-            <span>{hands[handIndex]}</span> Built by students @
+            <span>{hands[handIndex]}</span> Built by students @VikeLabs
           </Text>
-          <Image src={process.env.PUBLIC_URL + '/assets/vikelabs.svg'} alt="VikeLabs" />
         </Flex>
       </GridItem>
       <GridItem maxH="563px" minW="fit-content" display={{ base: 'none', xl: 'initial' }}>


### PR DESCRIPTION
## Overview

Closes #156 

* Add responsive design to the landing page content.

The `VIKE LABS` part of the landing page is still open for changes. Feel free to give a better alternative or modifications.

NOTE: This does not fix the height + content issue, and only fixes the responsiveness. 

## Screenshots

## Large Desktop

<img width="1673" alt="Capture d’écran, le 2021-06-04 à 21 02 54" src="https://user-images.githubusercontent.com/10472448/120879761-7d12d400-c57a-11eb-9bdb-7b43e3cd6d7f.png">

## Medium Desktop 

<img width="1266" alt="Capture d’écran, le 2021-06-04 à 20 51 43" src="https://user-images.githubusercontent.com/10472448/120879754-797f4d00-c57a-11eb-82d3-a2fb9f09a925.png">

## Small Screen

<img width="566" alt="Capture d’écran, le 2021-06-04 à 20 51 56" src="https://user-images.githubusercontent.com/10472448/120879758-7c7a3d80-c57a-11eb-942c-04374866e949.png">

## Smallest Screen

<img width="437" alt="Capture d’écran, le 2021-06-04 à 20 52 22" src="https://user-images.githubusercontent.com/10472448/120879760-7c7a3d80-c57a-11eb-9d6d-11b86066272f.png">

Known Issue:

This will not be fixed in this PR as it is more relevant to course scheduling page than landing page. This will need to be fixed once a suitable responsive design is created for this page.

<img width="1292" alt="Capture d’écran, le 2021-06-04 à 21 27 45" src="https://user-images.githubusercontent.com/10472448/120879930-bef04a00-c57b-11eb-9f72-3cb81a34e3db.png">
