### PR TITLE
fix: stop having forked repos try jobs that need repo secrets

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -61,7 +61,7 @@ jobs:
           path: build
   deploy-preview:
     name: Deploy to Firebase Hosting Preview
-    if: github.ref != 'refs/heads/main'
+    if: ${{ github.ref != 'refs/heads/main' && github.repository_owner == 'VikeLabs'}}  
     runs-on: ubuntu-latest
     needs: [ lint, build ]
     steps:


### PR DESCRIPTION
Stops having the preview builds trying to execute when they can't due to not having access to repository secrets. 