### PR TITLE
Registration view

### DIFF
--- a/src/app/header/components/TermButtons.tsx
+++ b/src/app/header/components/TermButtons.tsx
@@ -16,6 +16,7 @@ export function TermButtons(): JSX.Element {
 
   const calendarMatch = useMatch('/calendar/*');
   const scheduleMatch = useMatch('/schedule/*');
+  const registrationMatch = useMatch('/registration/*');
 
   const navigate = useNavigate();
 
@@ -35,6 +36,8 @@ export function TermButtons(): JSX.Element {
         navigate({ pathname: `/calendar/${name}/${subject || ''}`, search: pid ? `?pid=${pid}` : undefined });
       } else if (scheduleMatch) {
         navigate(`/scheduler/${name}`);
+      } else if (registrationMatch) {
+        navigate(`/registration/${name}`);
       } else {
         navigate(`/calendar/${name}`);
       }

--- a/src/app/registration/components/RegistrationHeading.tsx
+++ b/src/app/registration/components/RegistrationHeading.tsx
@@ -1,0 +1,65 @@
+import { Box, Divider, Heading, Text } from '@chakra-ui/layout';
+import { Button, Icon } from '@chakra-ui/react';
+import { HiLink } from 'react-icons/hi';
+import { IoCopyOutline } from 'react-icons/io5';
+import { useParams } from 'react-router';
+
+import { getReadableTerm } from '../../shared/utils/terms';
+
+export function RegistrationHeading() {
+  const { term } = useParams();
+
+  return (
+    <Box alignItems="center">
+      <Heading mr="5" size="xl" as="h1" whiteSpace="pre" color="black">
+        Registration for {`${getReadableTerm(term)}`}
+      </Heading>
+      <Divider my="5" />
+      <Box textAlign="left" mb="5">
+        <Text>
+          UVic offers a quick way to register for courses with the{' '}
+          <Text
+            as="span"
+            title="The 5-digit identifier of a section"
+            textDecoration="underline"
+            cursor="help"
+            style={{ textDecorationStyle: 'dotted' }}
+          >
+            CRNs
+          </Text>{' '}
+          of your desired sections. By clicking the button below, you will be taken to the page to do so in a new tab.
+          From this page, once you’ve selected a term, you can quickly{' '}
+          <Text as="span" fontWeight="bold">
+            {' '}
+            copy <Icon as={IoCopyOutline} />{' '}
+          </Text>
+          the{' '}
+          <Text
+            as="span"
+            title="The 5-digit identifier of a section"
+            textDecoration="underline"
+            cursor="help"
+            style={{ textDecorationStyle: 'dotted' }}
+          >
+            CRNs
+          </Text>{' '}
+          provided and paste them in the designated areas on UVic’s page, select{' '}
+          <Text as="span" fontWeight="bold">
+            Submit Changes
+          </Text>
+          , and you’re registered!
+        </Text>
+      </Box>
+      <Button
+        colorScheme="blue"
+        rightIcon={<HiLink />}
+        as="a"
+        href="https://www.uvic.ca/tools/student/registration/add-or-drop-classes/index.php"
+        target="_blank"
+      >
+        UVic Registration Page
+      </Button>
+      <Divider my="5" />
+    </Box>
+  );
+}

--- a/src/app/registration/components/RegistrationHeading.tsx
+++ b/src/app/registration/components/RegistrationHeading.tsx
@@ -37,8 +37,7 @@ export function RegistrationHeading() {
           UVic Registration Page
         </Button>
       </HStack>
-
-      <Divider my="5" />
+      <Divider my="3" />
       <Text w="100%" textAlign="left">
         UVic offers a quick way to register for courses with the{' '}
         <Text

--- a/src/app/registration/components/RegistrationHeading.tsx
+++ b/src/app/registration/components/RegistrationHeading.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeftIcon } from '@chakra-ui/icons';
-import { Box, Divider, Heading, HStack, Text } from '@chakra-ui/layout';
+import { Box, Divider, Heading, HStack, ListItem, OrderedList, Text } from '@chakra-ui/layout';
 import { Button, Icon, IconButton } from '@chakra-ui/react';
 import { HiLink } from 'react-icons/hi';
 import { IoCopyOutline } from 'react-icons/io5';
@@ -50,31 +50,52 @@ export function RegistrationHeading() {
         >
           CRNs
         </Text>{' '}
-        of your desired sections. By clicking the{' '}
-        <Text as="span" fontWeight="bold">
-          UVic Registration Page
-        </Text>{' '}
-        button, you will be taken to the page to do so in a new tab. From this page, once you’ve selected a term, you
-        can quickly{' '}
-        <Text as="span" fontWeight="bold">
-          {' '}
-          copy <Icon as={IoCopyOutline} />{' '}
-        </Text>
-        the{' '}
-        <Text
-          as="span"
-          title="The 5-digit identifier of a section"
-          textDecoration="underline"
-          cursor="help"
-          style={{ textDecorationStyle: 'dotted' }}
-        >
-          CRNs
-        </Text>{' '}
-        provided and paste them in the designated areas on UVic’s page, select{' '}
-        <Text as="span" fontWeight="bold">
-          Submit Changes
-        </Text>
-        , and you’re registered!
+        of your desired sections. Follow the given steps to register in the sections chosen and saved on the timetable
+        builder:{' '}
+        <OrderedList mt="1">
+          <ListItem>
+            Click the{' '}
+            <Text as="span" fontWeight="bold">
+              UVic Registration Page
+            </Text>{' '}
+            button.
+          </ListItem>
+          <ListItem>Sign in to UVic with your netlink ID.</ListItem>
+          <ListItem>
+            Select the appropriate term and hit{' '}
+            <Text as="span" fontWeight="bold">
+              Submit
+            </Text>{' '}
+            to take you to the{' '}
+            <Text as="span" fontWeight="bold">
+              Add or drop classes page.
+            </Text>
+          </ListItem>
+          <ListItem>
+            <Text as="span" fontWeight="bold">
+              {' '}
+              Copy <Icon as={IoCopyOutline} />{' '}
+            </Text>{' '}
+            and paste the{' '}
+            <Text
+              as="span"
+              title="The 5-digit identifier of a section"
+              textDecoration="underline"
+              cursor="help"
+              style={{ textDecorationStyle: 'dotted' }}
+            >
+              CRNs
+            </Text>{' '}
+            below into the input fields on UVic's page.
+          </ListItem>
+          <ListItem>
+            Hit{' '}
+            <Text as="span" fontWeight="bold">
+              Submit Changes
+            </Text>
+            , and you’re registered!
+          </ListItem>
+        </OrderedList>
       </Text>
     </Box>
   );

--- a/src/app/registration/components/RegistrationHeading.tsx
+++ b/src/app/registration/components/RegistrationHeading.tsx
@@ -59,7 +59,6 @@ export function RegistrationHeading() {
       >
         UVic Registration Page
       </Button>
-      <Divider my="5" />
     </Box>
   );
 }

--- a/src/app/registration/components/RegistrationHeading.tsx
+++ b/src/app/registration/components/RegistrationHeading.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeftIcon } from '@chakra-ui/icons';
-import { Box, Divider, Heading, HStack, ListItem, OrderedList, Text } from '@chakra-ui/layout';
+import { Box, Divider, Flex, Heading, HStack, ListItem, OrderedList, Text } from '@chakra-ui/layout';
 import { Button, Icon, IconButton } from '@chakra-ui/react';
 import { HiLink } from 'react-icons/hi';
 import { IoCopyOutline } from 'react-icons/io5';
@@ -13,7 +13,7 @@ export function RegistrationHeading() {
 
   return (
     <Box alignItems="center">
-      <HStack justifyContent="space-between">
+      <Flex direction={{ md: 'row', base: 'column' }} justifyContent="space-between">
         <HStack>
           <IconButton
             icon={<ChevronLeftIcon fontSize="35px" />}
@@ -23,7 +23,7 @@ export function RegistrationHeading() {
             as={Link}
             to={`/scheduler/${term}`}
           />
-          <Heading size="xl" as="h1" whiteSpace="pre" color="black">
+          <Heading size="xl" as="h1" color="black">
             Registration for {`${getReadableTerm(term)}`}
           </Heading>
         </HStack>
@@ -36,7 +36,7 @@ export function RegistrationHeading() {
         >
           UVic Registration Page
         </Button>
-      </HStack>
+      </Flex>
       <Divider my="3" />
       <Text w="100%" textAlign="left">
         UVic offers a quick way to register for courses with the{' '}

--- a/src/app/registration/components/RegistrationHeading.tsx
+++ b/src/app/registration/components/RegistrationHeading.tsx
@@ -1,8 +1,10 @@
-import { Box, Divider, Heading, Text } from '@chakra-ui/layout';
-import { Button, Icon } from '@chakra-ui/react';
+import { ChevronLeftIcon } from '@chakra-ui/icons';
+import { Box, Divider, Heading, HStack, Text } from '@chakra-ui/layout';
+import { Button, Icon, IconButton } from '@chakra-ui/react';
 import { HiLink } from 'react-icons/hi';
 import { IoCopyOutline } from 'react-icons/io5';
 import { useParams } from 'react-router';
+import { Link } from 'react-router-dom';
 
 import { getReadableTerm } from '../../shared/utils/terms';
 
@@ -11,54 +13,69 @@ export function RegistrationHeading() {
 
   return (
     <Box alignItems="center">
-      <Heading mr="5" size="xl" as="h1" whiteSpace="pre" color="black">
-        Registration for {`${getReadableTerm(term)}`}
-      </Heading>
+      <HStack justifyContent="space-between">
+        <HStack>
+          <IconButton
+            icon={<ChevronLeftIcon fontSize="35px" />}
+            colorScheme="white"
+            color="black"
+            aria-label="back"
+            as={Link}
+            to={`/scheduler/${term}`}
+          />
+          <Heading size="xl" as="h1" whiteSpace="pre" color="black">
+            Registration for {`${getReadableTerm(term)}`}
+          </Heading>
+        </HStack>
+        <Button
+          colorScheme="blue"
+          rightIcon={<HiLink />}
+          as="a"
+          href="https://www.uvic.ca/tools/student/registration/add-or-drop-classes/index.php"
+          target="_blank"
+        >
+          UVic Registration Page
+        </Button>
+      </HStack>
+
       <Divider my="5" />
-      <Box textAlign="left" mb="5">
-        <Text>
-          UVic offers a quick way to register for courses with the{' '}
-          <Text
-            as="span"
-            title="The 5-digit identifier of a section"
-            textDecoration="underline"
-            cursor="help"
-            style={{ textDecorationStyle: 'dotted' }}
-          >
-            CRNs
-          </Text>{' '}
-          of your desired sections. By clicking the button below, you will be taken to the page to do so in a new tab.
-          From this page, once you’ve selected a term, you can quickly{' '}
-          <Text as="span" fontWeight="bold">
-            {' '}
-            copy <Icon as={IoCopyOutline} />{' '}
-          </Text>
-          the{' '}
-          <Text
-            as="span"
-            title="The 5-digit identifier of a section"
-            textDecoration="underline"
-            cursor="help"
-            style={{ textDecorationStyle: 'dotted' }}
-          >
-            CRNs
-          </Text>{' '}
-          provided and paste them in the designated areas on UVic’s page, select{' '}
-          <Text as="span" fontWeight="bold">
-            Submit Changes
-          </Text>
-          , and you’re registered!
+      <Text w="100%" textAlign="left">
+        UVic offers a quick way to register for courses with the{' '}
+        <Text
+          as="span"
+          title="The 5-digit identifier of a section"
+          textDecoration="underline"
+          cursor="help"
+          style={{ textDecorationStyle: 'dotted' }}
+        >
+          CRNs
+        </Text>{' '}
+        of your desired sections. By clicking the{' '}
+        <Text as="span" fontWeight="bold">
+          UVic Registration Page
+        </Text>{' '}
+        button, you will be taken to the page to do so in a new tab. From this page, once you’ve selected a term, you
+        can quickly{' '}
+        <Text as="span" fontWeight="bold">
+          {' '}
+          copy <Icon as={IoCopyOutline} />{' '}
         </Text>
-      </Box>
-      <Button
-        colorScheme="blue"
-        rightIcon={<HiLink />}
-        as="a"
-        href="https://www.uvic.ca/tools/student/registration/add-or-drop-classes/index.php"
-        target="_blank"
-      >
-        UVic Registration Page
-      </Button>
+        the{' '}
+        <Text
+          as="span"
+          title="The 5-digit identifier of a section"
+          textDecoration="underline"
+          cursor="help"
+          style={{ textDecorationStyle: 'dotted' }}
+        >
+          CRNs
+        </Text>{' '}
+        provided and paste them in the designated areas on UVic’s page, select{' '}
+        <Text as="span" fontWeight="bold">
+          Submit Changes
+        </Text>
+        , and you’re registered!
+      </Text>
     </Box>
   );
 }

--- a/src/app/registration/components/RegistrationMinimized.tsx
+++ b/src/app/registration/components/RegistrationMinimized.tsx
@@ -1,0 +1,37 @@
+import { Checkbox } from '@chakra-ui/checkbox';
+import { Heading, HStack } from '@chakra-ui/layout';
+import { useCallback } from 'react';
+
+type Props = {
+  subject: string;
+  code: string;
+  lecture?: string;
+  lab?: string;
+  tutorial?: string;
+  handleChange: () => void;
+};
+
+export function RegistrationMinimized({ subject, code, lecture, lab, tutorial, handleChange }: Props) {
+  const sections = [lecture ?? '', lab ?? '', tutorial ?? ''];
+
+  const onChange = useCallback(() => {
+    handleChange();
+  }, [handleChange]);
+
+  return (
+    <HStack justifyContent="space-between">
+      <HStack>
+        <Heading size="lg" as="h2" textAlign="left" my="2" mr="2">
+          {subject} {code}
+        </Heading>
+        <Heading size="lg" as="h2" fontWeight="normal" color="rgb(155, 155, 155)">
+          {sections.filter((section) => section !== '').join(', ')}
+        </Heading>
+      </HStack>
+
+      <Checkbox defaultChecked onChange={onChange}>
+        Registered
+      </Checkbox>
+    </HStack>
+  );
+}

--- a/src/app/registration/components/RegistrationMinimized.tsx
+++ b/src/app/registration/components/RegistrationMinimized.tsx
@@ -24,11 +24,10 @@ export function RegistrationMinimized({ subject, code, lecture, lab, tutorial, h
         <Heading size="lg" as="h2" textAlign="left" my="2" mr="2">
           {subject} {code}
         </Heading>
-        <Heading size="lg" as="h2" fontWeight="normal" color="rgb(155, 155, 155)">
+        <Heading size="md" as="h3" color="gray">
           {sections.filter((section) => section !== '').join(', ')}
         </Heading>
       </HStack>
-
       <Checkbox defaultChecked onChange={onChange}>
         Registered
       </Checkbox>

--- a/src/app/registration/components/RegistrationSection.tsx
+++ b/src/app/registration/components/RegistrationSection.tsx
@@ -1,7 +1,7 @@
 import { IconButton } from '@chakra-ui/button';
 import { Checkbox } from '@chakra-ui/checkbox';
 import { useClipboard } from '@chakra-ui/hooks';
-import { Box, Heading, HStack, Text } from '@chakra-ui/layout';
+import { Box, Heading, HStack } from '@chakra-ui/layout';
 import { useToast } from '@chakra-ui/toast';
 import { useCallback, useEffect } from 'react';
 import { IoCopyOutline } from 'react-icons/io5';
@@ -33,8 +33,13 @@ export function RegistrationSection({ section, crn, seats, selected, handleChang
     <Box py="2">
       <HStack justifyContent="space-between">
         <Heading size="md" as="h3" mt="2">
-          {section}{' '}
-          <Text as="span" fontWeight="normal" ml="2" color="rgb(155, 155, 155)">
+          {section}
+        </Heading>
+        <HStack spacing="3">
+          <Checkbox isChecked={selected} onChange={onChange}>
+            Registered
+          </Checkbox>
+          <Heading size="md" as="h3" color="gray">
             {crn}
             <IconButton
               icon={<IoCopyOutline />}
@@ -42,6 +47,8 @@ export function RegistrationSection({ section, crn, seats, selected, handleChang
               aria-label="copy"
               colorScheme="white"
               color="black"
+              size="lg"
+              ml="-2.5"
               _focus={{
                 outline: 'none',
               }}
@@ -49,11 +56,8 @@ export function RegistrationSection({ section, crn, seats, selected, handleChang
                 color: 'rgb(155, 155, 155)',
               }}
             />
-          </Text>
-        </Heading>
-        <Checkbox isChecked={selected} onChange={onChange}>
-          Registered
-        </Checkbox>
+          </Heading>
+        </HStack>
       </HStack>
       <SeatInfo seat={seats} />
     </Box>

--- a/src/app/registration/components/RegistrationSection.tsx
+++ b/src/app/registration/components/RegistrationSection.tsx
@@ -1,5 +1,5 @@
 import { Checkbox } from '@chakra-ui/checkbox';
-import { Box, Heading, HStack, Text, VStack } from '@chakra-ui/layout';
+import { Box, Heading, HStack, Text } from '@chakra-ui/layout';
 import { useCallback } from 'react';
 
 import { Seat } from '../../../shared/fetchers';

--- a/src/app/registration/components/RegistrationSection.tsx
+++ b/src/app/registration/components/RegistrationSection.tsx
@@ -1,6 +1,10 @@
+import { IconButton } from '@chakra-ui/button';
 import { Checkbox } from '@chakra-ui/checkbox';
+import { useClipboard } from '@chakra-ui/hooks';
 import { Box, Heading, HStack, Text } from '@chakra-ui/layout';
-import { useCallback } from 'react';
+import { useToast } from '@chakra-ui/toast';
+import { useCallback, useEffect } from 'react';
+import { IoCopyOutline } from 'react-icons/io5';
 
 import { Seat } from '../../../shared/fetchers';
 import { SeatInfo } from '../../content/components/Seats';
@@ -14,6 +18,13 @@ type Props = {
 };
 
 export function RegistrationSection({ section, crn, seats, selected, handleChange }: Props) {
+  const { hasCopied, onCopy } = useClipboard(crn);
+  const toast = useToast();
+
+  useEffect(() => {
+    hasCopied && toast({ status: 'success', title: `Copied ${crn} to clipboard!` });
+  }, [crn, hasCopied, toast]);
+
   const onChange = useCallback(() => {
     handleChange({ crn, seats, selected });
   }, [crn, handleChange, seats, selected]);
@@ -25,6 +36,19 @@ export function RegistrationSection({ section, crn, seats, selected, handleChang
           {section}{' '}
           <Text as="span" fontWeight="normal" ml="2" color="rgb(155, 155, 155)">
             {crn}
+            <IconButton
+              icon={<IoCopyOutline />}
+              onClick={onCopy}
+              aria-label="copy"
+              colorScheme="white"
+              color="rgb(155, 155, 155)"
+              _focus={{
+                outline: 'none',
+              }}
+              _active={{
+                color: 'black',
+              }}
+            />
           </Text>
         </Heading>
         <Checkbox isChecked={selected} onChange={onChange}>

--- a/src/app/registration/components/RegistrationSection.tsx
+++ b/src/app/registration/components/RegistrationSection.tsx
@@ -1,0 +1,37 @@
+import { Checkbox } from '@chakra-ui/checkbox';
+import { Box, Heading, HStack, Text, VStack } from '@chakra-ui/layout';
+import { useCallback } from 'react';
+
+import { Seat } from '../../../shared/fetchers';
+import { SeatInfo } from '../../content/components/Seats';
+
+type Props = {
+  section: string;
+  crn: string;
+  seats?: Seat;
+  selected: boolean;
+  handleChange: ({ crn, seats, selected }: { crn: string; seats?: Seat; selected: boolean }) => void;
+};
+
+export function RegistrationSection({ section, crn, seats, selected, handleChange }: Props) {
+  const onChange = useCallback(() => {
+    handleChange({ crn, seats, selected });
+  }, [crn, handleChange, seats, selected]);
+
+  return (
+    <Box py="2">
+      <HStack justifyContent="space-between">
+        <Heading size="md" as="h3" mt="2">
+          {section}{' '}
+          <Text as="span" fontWeight="normal" ml="2" color="rgb(155, 155, 155)">
+            {crn}
+          </Text>
+        </Heading>
+        <Checkbox isChecked={selected} onChange={onChange}>
+          Registered
+        </Checkbox>
+      </HStack>
+      <SeatInfo seat={seats} />
+    </Box>
+  );
+}

--- a/src/app/registration/components/RegistrationSection.tsx
+++ b/src/app/registration/components/RegistrationSection.tsx
@@ -37,11 +37,11 @@ export function RegistrationSection({ section, crn, seats, additionalNotes, sele
         <Heading size="md" as="h3" mt="2">
           {section}
         </Heading>
-        <HStack spacing="3">
-          <Checkbox isChecked={selected} onChange={onChange}>
+        <HStack spacing="3" top="50%" minW="205px">
+          <Checkbox isChecked={selected} onChange={onChange} h="32px">
             Registered
           </Checkbox>
-          <Heading size="md" as="h3" color="gray">
+          <Heading size="md" as="h3" color="gray" h="32px">
             {crn}
             <IconButton
               icon={<IoCopyOutline />}
@@ -54,6 +54,7 @@ export function RegistrationSection({ section, crn, seats, additionalNotes, sele
               _focus={{
                 outline: 'none',
                 color: 'rgb(19, 135, 243)',
+                fontSize: '22.5px',
               }}
             />
           </Heading>

--- a/src/app/registration/components/RegistrationSection.tsx
+++ b/src/app/registration/components/RegistrationSection.tsx
@@ -1,3 +1,4 @@
+import { Accordion, AccordionButton, AccordionIcon, AccordionItem, AccordionPanel } from '@chakra-ui/accordion';
 import { IconButton } from '@chakra-ui/button';
 import { Checkbox } from '@chakra-ui/checkbox';
 import { useClipboard } from '@chakra-ui/hooks';
@@ -14,10 +15,11 @@ type Props = {
   crn: string;
   seats?: Seat;
   selected: boolean;
+  additionalNotes?: string;
   handleChange: ({ crn, seats, selected }: { crn: string; seats?: Seat; selected: boolean }) => void;
 };
 
-export function RegistrationSection({ section, crn, seats, selected, handleChange }: Props) {
+export function RegistrationSection({ section, crn, seats, additionalNotes, selected, handleChange }: Props) {
   const { hasCopied, onCopy } = useClipboard(crn);
   const toast = useToast();
 
@@ -47,18 +49,31 @@ export function RegistrationSection({ section, crn, seats, selected, handleChang
               aria-label="copy"
               colorScheme="white"
               color="black"
-              size="lg"
-              ml="-2.5"
+              size="sm"
+              fontSize="lg"
               _focus={{
                 outline: 'none',
-              }}
-              _active={{
-                color: 'rgb(155, 155, 155)',
+                color: 'rgb(19, 135, 243)',
               }}
             />
           </Heading>
         </HStack>
       </HStack>
+      {additionalNotes && (
+        <Accordion allowToggle my="3">
+          <AccordionItem>
+            <Heading as="h2">
+              <AccordionButton>
+                <Box flex="1" textAlign="left">
+                  Addtional Notes
+                </Box>
+                <AccordionIcon />
+              </AccordionButton>
+            </Heading>
+            <AccordionPanel pb={4}>{additionalNotes}</AccordionPanel>
+          </AccordionItem>
+        </Accordion>
+      )}
       <SeatInfo seat={seats} />
     </Box>
   );

--- a/src/app/registration/components/RegistrationSection.tsx
+++ b/src/app/registration/components/RegistrationSection.tsx
@@ -22,7 +22,7 @@ export function RegistrationSection({ section, crn, seats, selected, handleChang
   const toast = useToast();
 
   useEffect(() => {
-    hasCopied && toast({ status: 'success', title: `Copied ${crn} to clipboard!` });
+    hasCopied && toast({ status: 'info', title: `Copied ${crn} to clipboard!` });
   }, [crn, hasCopied, toast]);
 
   const onChange = useCallback(() => {
@@ -41,12 +41,12 @@ export function RegistrationSection({ section, crn, seats, selected, handleChang
               onClick={onCopy}
               aria-label="copy"
               colorScheme="white"
-              color="rgb(155, 155, 155)"
+              color="black"
               _focus={{
                 outline: 'none',
               }}
               _active={{
-                color: 'black',
+                color: 'rgb(155, 155, 155)',
               }}
             />
           </Text>

--- a/src/app/registration/components/RegistrationSection.tsx
+++ b/src/app/registration/components/RegistrationSection.tsx
@@ -38,7 +38,7 @@ export function RegistrationSection({ section, crn, seats, additionalNotes, sele
           {section}
         </Heading>
         <HStack spacing="3" top="50%" minW="205px">
-          <Checkbox isChecked={selected} onChange={onChange} h="32px">
+          <Checkbox isChecked={selected} onChange={onChange} size="lg" h="32px" mb="1">
             Registered
           </Checkbox>
           <Heading size="md" as="h3" color="gray" h="32px">

--- a/src/app/registration/components/RegistrationSection.tsx
+++ b/src/app/registration/components/RegistrationSection.tsx
@@ -38,7 +38,7 @@ export function RegistrationSection({ section, crn, seats, additionalNotes, sele
           {section}
         </Heading>
         <HStack spacing="3" top="50%" minW="205px">
-          <Checkbox isChecked={selected} onChange={onChange} size="lg" h="32px" mb="1">
+          <Checkbox isChecked={selected} onChange={onChange} size="lg" h="32px">
             Registered
           </Checkbox>
           <Heading size="md" as="h3" color="gray" h="32px">
@@ -49,6 +49,7 @@ export function RegistrationSection({ section, crn, seats, additionalNotes, sele
               aria-label="copy"
               colorScheme="white"
               color="black"
+              mb="1"
               size="sm"
               fontSize="lg"
               _focus={{

--- a/src/app/registration/containers/CourseContainer.tsx
+++ b/src/app/registration/containers/CourseContainer.tsx
@@ -1,6 +1,7 @@
 import { Heading, VStack } from '@chakra-ui/layout';
 import { Skeleton } from '@chakra-ui/skeleton';
-import { useCallback, useEffect, useState } from 'react';
+import { Collapse } from '@chakra-ui/transition';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 
 import { useSeats, useSections, Term, Seat } from '../../../shared/fetchers';
@@ -63,6 +64,12 @@ export function CourseContainer({ course }: Props) {
     [data]
   );
 
+  const isMinimized = useMemo(() => !data.lab?.selected && !data.lecture?.selected && !data.tutorial?.selected, [
+    data.lab?.selected,
+    data.lecture?.selected,
+    data.tutorial?.selected,
+  ]);
+
   const handleMinimizedChange = useCallback(() => {
     setData({
       lecture: data.lecture ? { crn: data.lecture.crn, seats: data.lecture.seats, selected: true } : undefined,
@@ -75,7 +82,7 @@ export function CourseContainer({ course }: Props) {
 
   return (
     <Skeleton isLoaded={!loading} color="black" my="4" boxShadow="md" p="3" rounded="lg" textAlign="left">
-      {!data.lab?.selected && !data.lecture?.selected && !data.tutorial?.selected ? (
+      {isMinimized && (
         <RegistrationMinimized
           subject={course.subject}
           code={course.code}
@@ -84,42 +91,41 @@ export function CourseContainer({ course }: Props) {
           tutorial={course.tutorial}
           handleChange={handleMinimizedChange}
         />
-      ) : (
-        <>
-          <Heading size="lg" as="h2" textAlign="left" my="2">
-            {course.subject} {course.code}
-          </Heading>
-          <VStack alignItems="left" mb="4">
-            {data.lecture && course.lecture && (
-              <RegistrationSection
-                section={course.lecture}
-                seats={data.lecture.seats}
-                crn={data.lecture.crn}
-                selected={!data.lecture.selected}
-                handleChange={handleChange}
-              />
-            )}
-            {data.lab && course.lab && (
-              <RegistrationSection
-                section={course.lab}
-                seats={data.lab.seats}
-                crn={data.lab.crn}
-                selected={!data.lab.selected}
-                handleChange={handleChange}
-              />
-            )}
-            {data.tutorial && course.tutorial && (
-              <RegistrationSection
-                section={course.tutorial}
-                seats={data.tutorial.seats}
-                crn={data.tutorial.crn}
-                selected={!data.tutorial.selected}
-                handleChange={handleChange}
-              />
-            )}
-          </VStack>
-        </>
       )}
+      <Collapse in={!isMinimized} animateOpacity>
+        <Heading size="lg" as="h2" textAlign="left" my="2">
+          {course.subject} {course.code}
+        </Heading>
+        <VStack alignItems="left" mb="4">
+          {data.lecture && course.lecture && (
+            <RegistrationSection
+              section={course.lecture}
+              seats={data.lecture.seats}
+              crn={data.lecture.crn}
+              selected={!data.lecture.selected}
+              handleChange={handleChange}
+            />
+          )}
+          {data.lab && course.lab && (
+            <RegistrationSection
+              section={course.lab}
+              seats={data.lab.seats}
+              crn={data.lab.crn}
+              selected={!data.lab.selected}
+              handleChange={handleChange}
+            />
+          )}
+          {data.tutorial && course.tutorial && (
+            <RegistrationSection
+              section={course.tutorial}
+              seats={data.tutorial.seats}
+              crn={data.tutorial.crn}
+              selected={!data.tutorial.selected}
+              handleChange={handleChange}
+            />
+          )}
+        </VStack>
+      </Collapse>
     </Skeleton>
   );
 }

--- a/src/app/registration/containers/CourseContainer.tsx
+++ b/src/app/registration/containers/CourseContainer.tsx
@@ -1,0 +1,125 @@
+import { Heading, VStack } from '@chakra-ui/layout';
+import { Skeleton } from '@chakra-ui/skeleton';
+import { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+
+import { useSeats, useSections, Term, Seat } from '../../../shared/fetchers';
+import { SavedCourse } from '../../../shared/hooks/useSavedCourses';
+import { RegistrationMinimized } from '../components/RegistrationMinimized';
+import { RegistrationSection } from '../components/RegistrationSection';
+
+type Props = {
+  course: SavedCourse;
+};
+
+type Data = {
+  crn: string;
+  seats?: Seat;
+  selected: boolean;
+};
+
+export function CourseContainer({ course }: Props) {
+  const { term } = useParams();
+  const [data, setData] = useState<{ lab?: Data; lecture?: Data; tutorial?: Data }>({});
+  const termType = term as Term;
+
+  const { data: sections, loading } = useSections({
+    term: termType,
+    queryParams: { subject: course.subject, code: course.code },
+  });
+  const { data: seats } = useSeats({
+    term: termType,
+    queryParams: { subject: course.subject, code: course.code },
+  });
+
+  useEffect(() => {
+    if (!loading) {
+      const lecture = sections?.find((section) => section.sectionCode === course.lecture);
+      const lab = sections?.find((section) => section.sectionCode === course.lab);
+      const tutorial = sections?.find((section) => section.sectionCode === course.tutorial);
+
+      setData({
+        lecture: lecture
+          ? { crn: lecture.crn, seats: seats?.find((e) => e.crn === lecture.crn), selected: true }
+          : undefined,
+        lab: lab ? { crn: lab.crn, seats: seats?.find((e) => e.crn === lab.crn), selected: true } : undefined,
+        tutorial: tutorial
+          ? { crn: tutorial.crn, seats: seats?.find((e) => e.crn === tutorial.crn), selected: true }
+          : undefined,
+      });
+    }
+  }, [course.lab, course.lecture, course.tutorial, loading, seats, sections]);
+
+  const handleChange = useCallback(
+    ({ crn, seats, selected }: Data) => {
+      if (data.lecture && data.lecture.crn === crn) {
+        setData({ ...data, lecture: { crn, seats, selected: selected } });
+      } else if (data.lab && data.lab.crn === crn) {
+        setData({ ...data, lab: { crn, seats, selected: selected } });
+      } else if (data.tutorial && data.tutorial.crn === crn) {
+        setData({ ...data, tutorial: { crn, seats, selected: selected } });
+      }
+    },
+    [data]
+  );
+
+  const handleMinimizedChange = useCallback(() => {
+    setData({
+      lecture: data.lecture ? { crn: data.lecture.crn, seats: data.lecture.seats, selected: true } : undefined,
+      lab: data.lab ? { crn: data.lab.crn, seats: data.lab.seats, selected: true } : undefined,
+      tutorial: data.tutorial ? { crn: data.tutorial.crn, seats: data.tutorial.seats, selected: true } : undefined,
+    });
+  }, [data.lab, data.lecture, data.tutorial]);
+
+  if (!course.selected) return null;
+
+  return (
+    <Skeleton isLoaded={!loading} color="black" my="4" boxShadow="md" p="3" rounded="lg" textAlign="left">
+      {!data.lab?.selected && !data.lecture?.selected && !data.tutorial?.selected ? (
+        <RegistrationMinimized
+          subject={course.subject}
+          code={course.code}
+          lecture={course.lecture}
+          lab={course.lab}
+          tutorial={course.tutorial}
+          handleChange={handleMinimizedChange}
+        />
+      ) : (
+        <>
+          <Heading size="lg" as="h2" textAlign="left" my="2">
+            {course.subject} {course.code}
+          </Heading>
+          <VStack alignItems="left" mb="4">
+            {data.lecture && course.lecture && (
+              <RegistrationSection
+                section={course.lecture}
+                seats={data.lecture.seats}
+                crn={data.lecture.crn}
+                selected={!data.lecture.selected}
+                handleChange={handleChange}
+              />
+            )}
+            {data.lab && course.lab && (
+              <RegistrationSection
+                section={course.lab}
+                seats={data.lab.seats}
+                crn={data.lab.crn}
+                selected={!data.lab.selected}
+                handleChange={handleChange}
+              />
+            )}
+            {data.tutorial && course.tutorial && (
+              <RegistrationSection
+                section={course.tutorial}
+                seats={data.tutorial.seats}
+                crn={data.tutorial.crn}
+                selected={!data.tutorial.selected}
+                handleChange={handleChange}
+              />
+            )}
+          </VStack>
+        </>
+      )}
+    </Skeleton>
+  );
+}

--- a/src/app/registration/containers/CourseContainer.tsx
+++ b/src/app/registration/containers/CourseContainer.tsx
@@ -15,6 +15,7 @@ type Props = {
 
 type Data = {
   crn: string;
+  additionalNotes?: string;
   seats?: Seat;
   selected: boolean;
 };
@@ -41,11 +42,28 @@ export function CourseContainer({ course }: Props) {
 
       setData({
         lecture: lecture
-          ? { crn: lecture.crn, seats: seats?.find((e) => e.crn === lecture.crn), selected: true }
+          ? {
+              crn: lecture.crn,
+              seats: seats?.find((e) => e.crn === lecture.crn),
+              additionalNotes: lecture.additionalNotes,
+              selected: true,
+            }
           : undefined,
-        lab: lab ? { crn: lab.crn, seats: seats?.find((e) => e.crn === lab.crn), selected: true } : undefined,
+        lab: lab
+          ? {
+              crn: lab.crn,
+              seats: seats?.find((e) => e.crn === lab.crn),
+              additionalNotes: lab.additionalNotes,
+              selected: true,
+            }
+          : undefined,
         tutorial: tutorial
-          ? { crn: tutorial.crn, seats: seats?.find((e) => e.crn === tutorial.crn), selected: true }
+          ? {
+              crn: tutorial.crn,
+              seats: seats?.find((e) => e.crn === tutorial.crn),
+              additionalNotes: tutorial.additionalNotes,
+              selected: true,
+            }
           : undefined,
       });
     }
@@ -54,11 +72,17 @@ export function CourseContainer({ course }: Props) {
   const handleChange = useCallback(
     ({ crn, seats, selected }: Data) => {
       if (data.lecture && data.lecture.crn === crn) {
-        setData({ ...data, lecture: { crn, seats, selected: selected } });
+        setData({
+          ...data,
+          lecture: { crn, seats, selected: selected, additionalNotes: data.lecture.additionalNotes },
+        });
       } else if (data.lab && data.lab.crn === crn) {
-        setData({ ...data, lab: { crn, seats, selected: selected } });
+        setData({ ...data, lab: { crn, seats, selected: selected, additionalNotes: data.lab.additionalNotes } });
       } else if (data.tutorial && data.tutorial.crn === crn) {
-        setData({ ...data, tutorial: { crn, seats, selected: selected } });
+        setData({
+          ...data,
+          tutorial: { crn, seats, selected: selected, additionalNotes: data.tutorial.additionalNotes },
+        });
       }
     },
     [data]
@@ -72,16 +96,42 @@ export function CourseContainer({ course }: Props) {
 
   const handleMinimizedChange = useCallback(() => {
     setData({
-      lecture: data.lecture ? { crn: data.lecture.crn, seats: data.lecture.seats, selected: true } : undefined,
-      lab: data.lab ? { crn: data.lab.crn, seats: data.lab.seats, selected: true } : undefined,
-      tutorial: data.tutorial ? { crn: data.tutorial.crn, seats: data.tutorial.seats, selected: true } : undefined,
+      lecture: data.lecture
+        ? {
+            crn: data.lecture.crn,
+            seats: data.lecture.seats,
+            selected: true,
+            additionalNotes: data.lecture.additionalNotes,
+          }
+        : undefined,
+      lab: data.lab
+        ? { crn: data.lab.crn, seats: data.lab.seats, selected: true, additionalNotes: data.lab.additionalNotes }
+        : undefined,
+      tutorial: data.tutorial
+        ? {
+            crn: data.tutorial.crn,
+            seats: data.tutorial.seats,
+            selected: true,
+            additionalNotes: data.tutorial.additionalNotes,
+          }
+        : undefined,
     });
   }, [data.lab, data.lecture, data.tutorial]);
 
   if (!course.selected) return null;
 
   return (
-    <Skeleton isLoaded={!loading} color="black" my="4" boxShadow="md" p="3" rounded="lg" textAlign="left">
+    <Skeleton
+      isLoaded={!loading}
+      color="black"
+      mt="4"
+      mb="2"
+      boxShadow="md"
+      px="3"
+      py="1"
+      rounded="lg"
+      textAlign="left"
+    >
       {isMinimized && (
         <RegistrationMinimized
           subject={course.subject}
@@ -93,16 +143,17 @@ export function CourseContainer({ course }: Props) {
         />
       )}
       <Collapse in={!isMinimized} animateOpacity>
-        <Heading size="lg" as="h2" textAlign="left" my="2">
+        <Heading size="lg" as="h2" textAlign="left">
           {course.subject} {course.code}
         </Heading>
-        <VStack alignItems="left" mb="4">
+        <VStack alignItems="left">
           {data.lecture && course.lecture && (
             <RegistrationSection
               section={course.lecture}
               seats={data.lecture.seats}
               crn={data.lecture.crn}
               selected={!data.lecture.selected}
+              additionalNotes={data.lecture.additionalNotes}
               handleChange={handleChange}
             />
           )}
@@ -112,6 +163,7 @@ export function CourseContainer({ course }: Props) {
               seats={data.lab.seats}
               crn={data.lab.crn}
               selected={!data.lab.selected}
+              additionalNotes={data.lab.additionalNotes}
               handleChange={handleChange}
             />
           )}
@@ -121,6 +173,7 @@ export function CourseContainer({ course }: Props) {
               seats={data.tutorial.seats}
               crn={data.tutorial.crn}
               selected={!data.tutorial.selected}
+              additionalNotes={data.tutorial.additionalNotes}
               handleChange={handleChange}
             />
           )}

--- a/src/app/registration/containers/RegistrationContainer.tsx
+++ b/src/app/registration/containers/RegistrationContainer.tsx
@@ -1,9 +1,10 @@
-import { Box, Flex } from '@chakra-ui/layout';
+import { Box, Divider, Flex, Heading } from '@chakra-ui/layout';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router';
 
 import { useSavedCourses } from '../../../shared/hooks/useSavedCourses';
 import { Header } from '../../header/Header';
+import { getReadableTerm } from '../../shared/utils/terms';
 import { RegistrationHeading } from '../components/RegistrationHeading';
 
 import { CourseContainer } from './CourseContainer';
@@ -13,19 +14,31 @@ export function RegistrationContainer(): JSX.Element | null {
   const { courses } = useSavedCourses();
 
   return (
-    <Flex h="100vh" direction="column" overflowX="hidden">
+    <Flex h="100vh" direction="column" overflowX="hidden" overflowY="hidden">
       <Helmet>
         <title>{`${term} · Registration`}</title>
       </Helmet>
       <Header />
-      <Flex width="100%" mt="20px" direction="column" alignItems="center">
-        <Box width={['container.md', 'container.lg', 'container.xl']} textAlign="center">
+      <Flex width="100%" pt="20px" direction="column" alignItems="center" overflowY="auto">
+        <Box width="60rem" textAlign="center">
           <RegistrationHeading />
-          {courses
-            .filter((course) => course.term === term)
-            .map((course) => {
-              return <CourseContainer course={course} />;
-            })}
+          {courses.filter((course) => course.term === term).length > 0 ? (
+            courses
+              .filter((course) => course.term === term)
+              .map((course) => {
+                return <CourseContainer course={course} />;
+              })
+          ) : (
+            <>
+              <Divider my="4" />
+              <Heading size="md" color="gray">
+                Unable to find saved courses for{' '}
+                <Box as="span" color="black">
+                  {getReadableTerm(term)}
+                </Box>
+              </Heading>
+            </>
+          )}
         </Box>
       </Flex>
     </Flex>

--- a/src/app/registration/containers/RegistrationContainer.tsx
+++ b/src/app/registration/containers/RegistrationContainer.tsx
@@ -21,7 +21,7 @@ export function RegistrationContainer(): JSX.Element | null {
       </Helmet>
       <Header />
       <Flex width="100%" pt="20px" direction="column" alignItems="center" overflowY="auto">
-        <Box width="60rem" textAlign="center">
+        <Box maxW={{ md: '60rem', sm: '35rem', base: '20rem' }} textAlign="center">
           <RegistrationHeading />
           {courses.filter((course) => course.term === term).length > 0 ? (
             courses

--- a/src/app/registration/containers/RegistrationContainer.tsx
+++ b/src/app/registration/containers/RegistrationContainer.tsx
@@ -17,7 +17,7 @@ export function RegistrationContainer(): JSX.Element | null {
   return (
     <Flex h="100vh" direction="column" overflowX="hidden" overflowY="hidden">
       <Helmet>
-        <title>{`${term} · Registration`}</title>
+        <title>{`${getReadableTerm(term)} · Registration`}</title>
       </Helmet>
       <Header />
       <Flex width="100%" pt="20px" direction="column" alignItems="center" overflowY="auto">

--- a/src/app/registration/containers/RegistrationContainer.tsx
+++ b/src/app/registration/containers/RegistrationContainer.tsx
@@ -21,7 +21,7 @@ export function RegistrationContainer(): JSX.Element | null {
       </Helmet>
       <Header />
       <Flex width="100%" pt="20px" direction="column" alignItems="center" overflowY="auto">
-        <Box maxW={{ md: '60rem', sm: '35rem', base: '20rem' }} textAlign="center">
+        <Box maxW={{ md: '65rem', sm: '35rem', base: '20rem' }} textAlign="center">
           <RegistrationHeading />
           {courses.filter((course) => course.term === term).length > 0 ? (
             courses

--- a/src/app/registration/containers/RegistrationContainer.tsx
+++ b/src/app/registration/containers/RegistrationContainer.tsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router';
 
 import { useSavedCourses } from '../../../shared/hooks/useSavedCourses';
+import { Feedback } from '../../feedback/Feedback';
 import { Header } from '../../header/Header';
 import { getReadableTerm } from '../../shared/utils/terms';
 import { RegistrationHeading } from '../components/RegistrationHeading';
@@ -41,6 +42,9 @@ export function RegistrationContainer(): JSX.Element | null {
           )}
         </Box>
       </Flex>
+      <Box pos="absolute" bottom="0" right="0" zIndex={999} p={25}>
+        <Feedback />
+      </Box>
     </Flex>
   );
 }

--- a/src/app/registration/containers/RegistrationContainer.tsx
+++ b/src/app/registration/containers/RegistrationContainer.tsx
@@ -1,0 +1,33 @@
+import { Box, Flex, Text } from '@chakra-ui/layout';
+import { Helmet } from 'react-helmet';
+import { useParams } from 'react-router';
+
+import { useSavedCourses } from '../../../shared/hooks/useSavedCourses';
+import { Header } from '../../header/Header';
+import { RegistrationHeading } from '../components/RegistrationHeading';
+
+import { CourseContainer } from './CourseContainer';
+
+export function RegistrationContainer(): JSX.Element | null {
+  const { term } = useParams();
+  const { courses } = useSavedCourses();
+
+  return (
+    <Flex h="100vh" direction="column" overflowX="hidden">
+      <Helmet>
+        <title>{`${term} · Registration`}</title>
+      </Helmet>
+      <Header />
+      <Flex width="100%" mt="20px" direction="column" alignItems="center">
+        <Box width={['container.md', 'container.lg', 'container.xl']} textAlign="center">
+          <RegistrationHeading />
+          {courses
+            .filter((course) => course.term === term)
+            .map((course) => {
+              return <CourseContainer course={course} />;
+            })}
+        </Box>
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/app/registration/containers/RegistrationContainer.tsx
+++ b/src/app/registration/containers/RegistrationContainer.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Text } from '@chakra-ui/layout';
+import { Box, Flex } from '@chakra-ui/layout';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router';
 

--- a/src/app/registration/index.tsx
+++ b/src/app/registration/index.tsx
@@ -1,0 +1,1 @@
+export { RegistrationContainer as Registration } from './containers/RegistrationContainer';

--- a/src/app/scheduler/components/SchedulerSidebar.tsx
+++ b/src/app/scheduler/components/SchedulerSidebar.tsx
@@ -2,6 +2,7 @@ import { Button } from '@chakra-ui/button';
 import { Box, Flex, Text, VStack } from '@chakra-ui/layout';
 import { Collapse } from '@chakra-ui/transition';
 import { useCallback } from 'react';
+import { Link } from 'react-router-dom';
 
 import { MeetingTimes } from '../../../shared/fetchers';
 import { useSavedCourses } from '../../../shared/hooks/useSavedCourses';
@@ -107,6 +108,16 @@ export function SchedulerSidebar({ term }: SchedulerSidebarProps): JSX.Element {
         <Flex justifyContent="space-between" alignItems="center" p="3">
           <Text>Saved Courses</Text>
           <Flex>
+            <Button
+              size="xs"
+              mr="1"
+              colorScheme="blue"
+              disabled={courses.filter((course) => course.term === term).length === 0}
+              as={Link}
+              to={`/registration/${term}`}
+            >
+              Register
+            </Button>
             <Button
               size="xs"
               colorScheme="red"

--- a/src/pages/registration/index.tsx
+++ b/src/pages/registration/index.tsx
@@ -1,0 +1,1 @@
+export { Registration } from '../../app/registration';

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes as ReactRouterRoutes, Route } from 'react-router-
 
 import { Calendar } from './pages/calendar';
 import { Home } from './pages/home';
+import { Registration } from './pages/registration';
 import { Scheduler } from './pages/scheduler';
 
 // TODO: use nested routes but it doesn't work right now
@@ -15,6 +16,7 @@ export function Routes(): JSX.Element {
         <Route path="/calendar/:term/*" element={<Calendar />} />
         <Route path="/scheduler/" element={<Scheduler />} />
         <Route path="/scheduler/:term/*" element={<Scheduler />} />
+        <Route path="/registration/:term" element={<Registration />} />
       </ReactRouterRoutes>
     </BrowserRouter>
   );


### PR DESCRIPTION
## Overview
<!-- Replace `XX` with the issue # you're working on -->
Closes #162 

<!-- Give a brief overview of the changes made -->
Adds a registration page users can access via the timetable which provides a link to UVic's registration page & easy-to-copy CRNs for each of their saved sections. The idea is users can quickly copy and paste CRNs into UVic's registration page to easily register based on their timetable made on the website.

**looking for any a11y recommendations** 

<!-- Provide a screenshot of any frontend changess -->
![Screen Shot 2021-06-06 at 2 28 00 PM](https://user-images.githubusercontent.com/53020925/120940720-82cffd00-c6d3-11eb-9a68-6d1e9ce3d2a9.png)
![Screen Shot 2021-06-06 at 2 28 37 PM](https://user-images.githubusercontent.com/53020925/120940722-85325700-c6d3-11eb-80d2-ddb80194daed.png)
![Screen Shot 2021-06-06 at 2 28 19 PM](https://user-images.githubusercontent.com/53020925/120940723-85caed80-c6d3-11eb-8263-813e05f3c2bb.png)
![Screen Shot 2021-06-06 at 2 28 09 PM](https://user-images.githubusercontent.com/53020925/120940724-85caed80-c6d3-11eb-8e3b-a8cf6150accd.png)

