### PR TITLE
Fix feedback button blocking course cards

### DIFF
--- a/src/app/scheduler/components/SchedulerSidebar.tsx
+++ b/src/app/scheduler/components/SchedulerSidebar.tsx
@@ -129,7 +129,7 @@ export function SchedulerSidebar({ term }: SchedulerSidebarProps): JSX.Element {
           </Flex>
         </Flex>
       </Box>
-      <Box h="100%" overflow="auto">
+      <Box h="100%" overflow="auto" pb="20">
         {coursesResult.status === 'loaded' &&
           coursesResult.data
             .filter((course) => course.term === term)
@@ -165,14 +165,7 @@ export function SchedulerSidebar({ term }: SchedulerSidebarProps): JSX.Element {
         borderColor="gray.200"
         borderBottomWidth="2px"
         borderBottomStyle="solid"
-      >
-        {/* TODO: summary for course registration */}
-        {/* <Flex justifyContent="space-between" alignItems="center" p="3">
-          <Button size="xs" colorScheme="green">
-            Summary
-          </Button>
-        </Flex> */}
-      </Box>
+      />
     </Flex>
   );
 }


### PR DESCRIPTION
## Overview
<!-- Replace `XX` with the issue # you're working on -->
Closes #204 

<!-- Give a brief overview of the changes made -->
Added some padding to the bottom of the scheduler sidebar to give room for the feedback button. This allows there to be space for the feedback button to occupy that doesn't cover a remove or info button of a saved course.

<!-- Provide a screenshot of any frontend changess -->
<img width="311" alt="Screen Shot 2021-06-09 at 7 44 08 PM" src="https://user-images.githubusercontent.com/53020925/121456655-41ea1980-c95b-11eb-925f-99cb2b13e625.png">

