### PR TITLE
feat: add git sha as static asset for frontend

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -49,6 +49,8 @@ jobs:
             npm-
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-progress
+      - name: Add version
+        run: echo ${{ github.sha }} > public/version
       - name: Build
         env:
           REACT_APP_SENTRY_RELEASE: ${{ github.sha }}


### PR DESCRIPTION
Adds a SHA as a static file to the application. This let's developers check which version of the application they are hitting.