### PR TITLE
change overflow hidden to auto

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,3 @@
 body {
-  overflow: hidden;
+  overflow: auto;
 }


### PR DESCRIPTION
## Overview
<!-- Replace `XX` with the issue # you're working on -->
Closes #209 

website cut off the text because overflow is set to hidden.
Change the setting to auto

<img width="1280" alt="Screen Shot 2021-06-11 at 9 13 04 AM" src="https://user-images.githubusercontent.com/24921825/121716917-795ce100-ca95-11eb-9c03-09876745694c.png">
