### PR TITLE
fix: sections being hidden for courses added before this feature

### DIFF
--- a/src/pages/scheduler/components/SchedulerSidebar.tsx
+++ b/src/pages/scheduler/components/SchedulerSidebar.tsx
@@ -173,7 +173,11 @@ export function SchedulerSidebar({ term }: SchedulerSidebarProps): JSX.Element {
                   handleDelete={handleCourseDelete}
                   handleShowSections={handleShowSections}
                 />
-                <Collapse in={course.showSections} animateOpacity style={{ width: '100%' }}>
+                <Collapse
+                  in={course.showSections !== undefined ? course.showSections : true}
+                  animateOpacity
+                  style={{ width: '100%' }}
+                >
                   <SectionsCardContainer
                     course={course}
                     courses={courses}

--- a/src/pages/scheduler/components/SchedulerSidebar.tsx
+++ b/src/pages/scheduler/components/SchedulerSidebar.tsx
@@ -168,7 +168,7 @@ export function SchedulerSidebar({ term }: SchedulerSidebarProps): JSX.Element {
                   color={course.color}
                   pid={course.pid}
                   selected={course.selected}
-                  showSections={course.showSections}
+                  showSections={course.showSections !== undefined ? course.showSections : true}
                   handleSelection={handleCourseToggle}
                   handleDelete={handleCourseDelete}
                   handleShowSections={handleShowSections}

--- a/src/pages/scheduler/components/SchedulerSidebar.tsx
+++ b/src/pages/scheduler/components/SchedulerSidebar.tsx
@@ -174,6 +174,7 @@ export function SchedulerSidebar({ term }: SchedulerSidebarProps): JSX.Element {
                   handleShowSections={handleShowSections}
                 />
                 <Collapse
+                  // hacky way of addressing the fact that `showSections` was added as an attribute after users have already added courses to the timetable
                   in={course.showSections !== undefined ? course.showSections : true}
                   animateOpacity
                   style={{ width: '100%' }}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change(s) and which issue is being fixed. Please provide as much detail as possible. -->

<!-- Replace `XX` with the concerning issue number. -->
#193 added the option to collapse courses on the timetable sidebar, however the edge case where users who had timetables made prior to this additional attribute being added was not addressed. Currently on staging if you already had courses added, they will default to be minimized since `showSections` is undefined, which isn't the end of the world but I'd rather we avoid this. 
