### PR TITLE
Fixed "Search Results" being wrong color in dark mode

### DIFF
--- a/src/common/sidebar/containers/SidebarContainer.tsx
+++ b/src/common/sidebar/containers/SidebarContainer.tsx
@@ -71,8 +71,8 @@ export function SidebarContainer({ searchQuery, term }: SidebarContainerProps): 
       >
         <Flex justifyContent="flex-start" height="100%" width="100%" overflow="hidden" direction="column">
           <Box>
-            <HStack bg="white" py="2" px="4" top="0" m="0" boxShadow="md" zIndex={500}>
-              <Heading pt="0.25em" color="black" size="sm">
+            <HStack py="2" px="4" top="0" m="0" boxShadow="md" zIndex={500}>
+              <Heading pt="0.25em" size="sm">
                 Search Results
               </Heading>
             </HStack>


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change(s) and which issue is being fixed. Please provide as much detail as possible. -->
Changed background colour of search results header to match dark mode

<!-- Replace `XX` with the concerning issue number. -->
Closes #269

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/48394084/129122913-651bbefe-04d8-4fc3-94ce-55e4d8194d17.png)

### After
![image](https://user-images.githubusercontent.com/48394084/129122935-3b6451db-cf19-462a-aedf-e9095c8e8296.png)

## Checklist

- [ ] The code follows all style guidelines.
- [x] The code passes all required tests.
- [ ] The code is documented.
- [ ] I have self-reviewed my changes and have done QA.