### PR TITLE
Bug Fix for issue #215 info button

### DIFF
--- a/src/common/sidebar/components/SearchResults.tsx
+++ b/src/common/sidebar/components/SearchResults.tsx
@@ -22,7 +22,7 @@ const SearchResults = ({ hits }: Props) => {
 
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     const pid = e.currentTarget.getAttribute('data-pid');
-    if (pid && scheduleMatch === null) {
+    if (pid && !scheduleMatch) {
       setSearchParams({ pid });
     }
   };

--- a/src/common/sidebar/components/SearchResults.tsx
+++ b/src/common/sidebar/components/SearchResults.tsx
@@ -22,7 +22,7 @@ const SearchResults = ({ hits }: Props) => {
 
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     const pid = e.currentTarget.getAttribute('data-pid');
-    if (pid) {
+    if (pid && scheduleMatch === null) {
       setSearchParams({ pid });
     }
   };


### PR DESCRIPTION
# Description

Fixes a bug that causes a click event on the info button on timeline search results to have a conflict with another click event. The click event on the button redirects the page to the course information page as intended.

Closes #215

## Screenshots

This bug and fix only applies to the course cards that appear in the search results of the Timeline page.

Clicking the blue info icon as shown in this image...
![image](https://user-images.githubusercontent.com/66714443/133047711-bf1226cc-53e8-4345-9392-ec67a66b9271.png)

### Before

...briefly shows the correct link address but is quickly replaced by an incorrect link address that also blocks the page from redirecting incorrectly.
![image](https://user-images.githubusercontent.com/66714443/133047919-b0da3c69-c733-4b9b-88d7-b050074ea3ae.png)

### After

...now is no longer blocked and redirects to the correct link address.
![image](https://user-images.githubusercontent.com/66714443/133048216-898d5560-96a3-4f70-816e-010bda2254ec.png)