### PR TITLE
fix: Prevent week view reset when course sections dropdown is triggered

### DIFF
--- a/src/lib/hooks/useSavedCourses.ts
+++ b/src/lib/hooks/useSavedCourses.ts
@@ -8,7 +8,7 @@ import { SECTION_TYPES, getFirstSectionType, hasSectionType } from 'lib/utils';
 
 import useLocalStorage from './storage/useLocalStorage';
 
-const OMITTED_FIELDS = ['lecture', 'lab', 'tutorial', 'color', 'sections', 'selected', 'showSections'];
+const OMITTED_FIELDS = ['lecture', 'lab', 'tutorial', 'color', 'sections', 'selected'];
 
 export const COLORS = [
   '#F56565', // red
@@ -32,7 +32,6 @@ export type SavedCourse = {
    * Whether the course is selected which typically implies displayed or not.
    */
   selected?: boolean;
-  showSections?: boolean;
 
   lecture?: string;
   lab?: string;
@@ -64,7 +63,6 @@ type SavedCourses = {
   contains: (pid: string, term: string) => boolean;
   sectionIsSaved: (pid: string, term: string, sectionCode: string) => boolean;
   setSelected: (selected: boolean, existingCourse: SavedCourse) => void;
-  setShowSections: (showSections: boolean, existingCourse: SavedCourse) => void;
 };
 
 export const useSavedCourses = (): SavedCourses => {
@@ -119,7 +117,7 @@ export const useSavedCourses = (): SavedCourses => {
       // avoid adding a course if it is saved already.
       if (contains(pid, term)) return;
 
-      const course: SavedCourse = { term, subject, code, pid, selected: true, showSections: true };
+      const course: SavedCourse = { term, subject, code, pid, selected: true };
       // we need to load in the course sections given we have no idea which default sections to select
       getSections({ term, subject, code }).then((sections) => {
         SECTION_TYPES.forEach(({ sectionName, sectionType }) => {
@@ -175,19 +173,6 @@ export const useSavedCourses = (): SavedCourses => {
       data.map((course) => {
         if (equals(course, existingCourse)) {
           course.selected = selected;
-          course.showSections = selected ? true : false;
-        }
-
-        return course;
-      })
-    );
-  };
-
-  const setShowSections = (showSections: boolean, existingCourse: SavedCourse) => {
-    setData(
-      data.map((course) => {
-        if (equals(course, existingCourse)) {
-          course.showSections = showSections;
         }
 
         return course;
@@ -204,6 +189,5 @@ export const useSavedCourses = (): SavedCourses => {
     contains,
     sectionIsSaved,
     setSelected,
-    setShowSections,
   };
 };

--- a/src/pages/scheduler/components/CourseCard.tsx
+++ b/src/pages/scheduler/components/CourseCard.tsx
@@ -87,7 +87,7 @@ export function CourseCard({
 
   return (
     <VStack key={key} mt="1" spacing="0" w="100%">
-      <Box boxShadow="md" cursor="pointer" as="label" w="100%" bgColor={mode('white', 'dark.main')}>
+      <Box boxShadow="md" w="100%" bgColor={mode('white', 'dark.main')}>
         <Flex direction="row">
           <Flex background={color} alignItems="center" justifyContent="center" mr="10px">
             <Flex>

--- a/src/pages/scheduler/components/CourseCard.tsx
+++ b/src/pages/scheduler/components/CourseCard.tsx
@@ -1,20 +1,27 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { ChevronDownIcon, ChevronUpIcon, CloseIcon } from '@chakra-ui/icons';
-import { Box, Text, Flex, VStack, Checkbox, IconButton, BackgroundProps, Skeleton } from '@chakra-ui/react';
+import { Box, Text, Flex, VStack, Checkbox, IconButton, BackgroundProps, Skeleton, Collapse } from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
 
-import { Term, useGetCourse } from 'lib/fetchers';
+import { MeetingTimes, Term, useGetCourse } from 'lib/fetchers';
 import { useDarkMode } from 'lib/hooks/useDarkMode';
+import { SavedCourse } from 'lib/hooks/useSavedCourses';
+
+import { SavedCourseWithSections } from '../shared/types';
+
+import { SectionsCardContainer } from './SchedulerSections';
 
 export type CourseCardProps = {
   term: string;
   subject: string;
   code: string;
   color: BackgroundProps['bg'];
+  course: SavedCourseWithSections;
+  courses: SavedCourse[];
   pid: string;
   selected?: boolean;
-  showSections?: boolean;
+  key: number;
   handleSelection: ({
     code,
     pid,
@@ -29,19 +36,15 @@ export type CourseCardProps = {
     selected?: boolean;
   }) => void;
   handleDelete: ({ code, pid, subject, term }: { code: string; pid: string; subject: string; term: string }) => void;
-  handleShowSections: ({
-    code,
-    pid,
-    subject,
-    term,
-    showSections,
-  }: {
-    code: string;
-    pid: string;
-    subject: string;
-    term: string;
-    showSections?: boolean;
-  }) => void;
+  handleCourseSectionChange: (
+    sectionType: string,
+    sectionCode: string,
+    meetingTimes: MeetingTimes[],
+    code: string,
+    subject: string,
+    pid: string,
+    term: string
+  ) => void;
 };
 
 export function CourseCard({
@@ -49,90 +52,109 @@ export function CourseCard({
   subject,
   code,
   color,
+  course,
+  courses,
   pid,
   selected,
-  showSections,
+  key,
   handleSelection,
-  handleShowSections,
   handleDelete,
+  handleCourseSectionChange,
 }: CourseCardProps): JSX.Element {
   const mode = useDarkMode();
+
   const onChange = useCallback(() => {
     handleSelection({ term, code, subject, pid, selected });
   }, [code, handleSelection, pid, selected, subject, term]);
 
-  const onShowSections = useCallback(() => {
-    handleShowSections({ term, code, subject, pid, showSections });
-  }, [code, handleShowSections, pid, showSections, subject, term]);
-
   const onDelete = useCallback(() => {
     handleDelete({ term, code, subject, pid });
   }, [code, handleDelete, pid, subject, term]);
+
+  const [showSections, setShowSections] = useState<boolean>(false);
+
+  const onShowSections = () => {
+    setShowSections(!showSections);
+  };
+
+  useEffect(() => {
+    setShowSections(!!selected);
+  }, [selected]);
 
   const termTerm = term as Term;
 
   const { data, loading } = useGetCourse({ term: termTerm, pid });
 
   return (
-    <Box boxShadow="md" cursor="pointer" as="label" w="100%" bgColor={mode('white', 'dark.main')}>
-      <Flex direction="row">
-        <Flex background={color} alignItems="center" justifyContent="center" mr="10px">
-          <Flex>
-            <Checkbox
-              backgroundColor="whiteAlpha.600"
-              colorScheme="whiteAlpha"
-              iconColor="black"
-              size="lg"
-              mx="7px"
-              isChecked={selected}
-              onChange={onChange}
-            />
+    <VStack key={key} mt="1" spacing="0" w="100%">
+      <Box boxShadow="md" cursor="pointer" as="label" w="100%" bgColor={mode('white', 'dark.main')}>
+        <Flex direction="row">
+          <Flex background={color} alignItems="center" justifyContent="center" mr="10px">
+            <Flex>
+              <Checkbox
+                backgroundColor="whiteAlpha.600"
+                colorScheme="whiteAlpha"
+                iconColor="black"
+                size="lg"
+                mx="7px"
+                isChecked={selected}
+                onChange={onChange}
+              />
+            </Flex>
           </Flex>
-        </Flex>
-        <Flex direction="row" alignItems="center" justifyContent="space-between" w="100%">
-          <Flex grow={1}>
-            <VStack
-              alignItems="start"
-              spacing="0"
-              py="2"
-              _hover={{
-                textDecoration: 'underline',
-              }}
-              as={Link}
-              to={`/calendar/${term}/${subject}?pid=${pid}`}
-            >
-              <Text fontSize="lg" fontWeight="bold" tabIndex={0}>
-                {subject} {code}
-              </Text>
-              <Text fontSize="sm" fontWeight="normal">
-                <Skeleton isLoaded={!loading}>{data?.title ?? ''}</Skeleton>
-              </Text>
+          <Flex direction="row" alignItems="center" justifyContent="space-between" w="100%">
+            <Flex grow={1}>
+              <VStack
+                alignItems="start"
+                spacing="0"
+                py="2"
+                _hover={{
+                  textDecoration: 'underline',
+                }}
+                as={Link}
+                to={`/calendar/${term}/${subject}?pid=${pid}`}
+              >
+                <Text fontSize="lg" fontWeight="bold" tabIndex={0}>
+                  {subject} {code}
+                </Text>
+                <Text fontSize="sm" fontWeight="normal">
+                  <Skeleton isLoaded={!loading}>{data?.title ?? ''}</Skeleton>
+                </Text>
+              </VStack>
+            </Flex>
+            <VStack alignContent="right" pr="3" py="5px">
+              <IconButton
+                aria-label="Remove from Scheduler"
+                icon={<CloseIcon />}
+                colorScheme="red"
+                size="xs"
+                onClick={onDelete}
+              />
+              <IconButton
+                aria-label="More information"
+                icon={
+                  showSections ? (
+                    <ChevronUpIcon color="white" boxSize="1.5em" />
+                  ) : (
+                    <ChevronDownIcon color="white" boxSize="1.5em" />
+                  )
+                }
+                colorScheme="blue"
+                size="xs"
+                onClick={onShowSections}
+              />
             </VStack>
           </Flex>
-          <VStack alignContent="right" pr="3" py="5px">
-            <IconButton
-              aria-label="Remove from Scheduler"
-              icon={<CloseIcon />}
-              colorScheme="red"
-              size="xs"
-              onClick={onDelete}
-            />
-            <IconButton
-              aria-label="More information"
-              icon={
-                showSections ? (
-                  <ChevronUpIcon color="white" boxSize="1.5em" />
-                ) : (
-                  <ChevronDownIcon color="white" boxSize="1.5em" />
-                )
-              }
-              colorScheme="blue"
-              size="xs"
-              onClick={onShowSections}
-            />
-          </VStack>
         </Flex>
-      </Flex>
-    </Box>
+      </Box>
+      <Collapse in={showSections} animateOpacity style={{ width: '100%' }}>
+        <SectionsCardContainer
+          course={course}
+          courses={courses}
+          sections={course.sections}
+          handleChange={handleCourseSectionChange}
+        />
+      </Collapse>
+    </VStack>
   );
 }

--- a/src/pages/scheduler/components/SchedulerSidebar.tsx
+++ b/src/pages/scheduler/components/SchedulerSidebar.tsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 
 import { Button } from '@chakra-ui/button';
 import { Box, Flex, Text, VStack } from '@chakra-ui/layout';
-import { Collapse } from '@chakra-ui/transition';
 import { Link } from 'react-router-dom';
 
 import { MeetingTimes } from 'lib/fetchers';
@@ -12,7 +11,6 @@ import { useSavedCourses } from 'lib/hooks/useSavedCourses';
 import { useGetCourseSections } from '../hooks/useCalendarEvents';
 
 import { CourseCard } from './CourseCard';
-import { SectionsCardContainer } from './SchedulerSections';
 
 // GREEN, RED, YELLOW, BLUE, PURPLE, ORANGE
 export const COLORS = ['#32a852', '#b33127', '#e8e523', '#247fe0', '#971dcc', '#cc7d1d'];
@@ -22,7 +20,7 @@ interface SchedulerSidebarProps {
 }
 
 export function SchedulerSidebar({ term }: SchedulerSidebarProps): JSX.Element {
-  const { deleteCourse, setSection, setShowSections, courses, setSelected, clearCourses } = useSavedCourses();
+  const { deleteCourse, setSection, courses, setSelected, clearCourses } = useSavedCourses();
   const coursesResult = useGetCourseSections(term, courses);
   const mode = useDarkMode();
 
@@ -89,30 +87,6 @@ export function SchedulerSidebar({ term }: SchedulerSidebarProps): JSX.Element {
     [setSelected]
   );
 
-  const handleShowSections = useCallback(
-    ({
-      code,
-      pid,
-      subject,
-      term,
-      showSections,
-    }: {
-      code: string;
-      pid: string;
-      subject: string;
-      term: string;
-      showSections?: boolean;
-    }) => {
-      setShowSections(!showSections, {
-        code,
-        pid,
-        subject,
-        term,
-      });
-    },
-    [setShowSections]
-  );
-
   return (
     <Flex
       minW="25%"
@@ -173,30 +147,19 @@ export function SchedulerSidebar({ term }: SchedulerSidebarProps): JSX.Element {
             .map((course, key) => (
               <VStack key={key} mt="1" spacing="0">
                 <CourseCard
+                  key={key}
                   term={course.term}
                   subject={course.subject}
                   code={course.code}
                   color={course.color}
+                  course={course}
+                  courses={courses}
                   pid={course.pid}
                   selected={course.selected}
-                  showSections={course.showSections !== undefined ? course.showSections : true}
                   handleSelection={handleCourseToggle}
                   handleDelete={handleCourseDelete}
-                  handleShowSections={handleShowSections}
+                  handleCourseSectionChange={handleCourseSectionChange}
                 />
-                <Collapse
-                  // hacky way of addressing the fact that `showSections` was added as an attribute after users have already added courses to the timetable
-                  in={course.showSections !== undefined ? course.showSections : true}
-                  animateOpacity
-                  style={{ width: '100%' }}
-                >
-                  <SectionsCardContainer
-                    course={course}
-                    courses={courses}
-                    sections={course.sections}
-                    handleChange={handleCourseSectionChange}
-                  />
-                </Collapse>
               </VStack>
             ))}
       </Box>

--- a/src/pages/scheduler/hooks/useCalendarEvents.tsx
+++ b/src/pages/scheduler/hooks/useCalendarEvents.tsx
@@ -29,32 +29,29 @@ export function useGetCourseSections(term: string, courses: SavedCourse[]) {
     (async () => {
       try {
         const coursesSections = await Promise.all(
-          termCourses.map(
-            async ({ term, subject, code, pid, lecture, lab, tutorial, selected, showSections, color }) => {
-              const key = `${term}_${subject}_${code}`;
-              const cachedSections = SECTIONS_CACHE[key];
+          termCourses.map(async ({ term, subject, code, pid, lecture, lab, tutorial, selected, color }) => {
+            const key = `${term}_${subject}_${code}`;
+            const cachedSections = SECTIONS_CACHE[key];
 
-              if (!cachedSections) {
-                const sections = await getSections({ term, subject, code });
-                SECTIONS_CACHE[key] = sections;
-              }
-              // TODO: transform into calendar events :wink:
-
-              return {
-                sections: SECTIONS_CACHE[key],
-                term,
-                subject,
-                code,
-                pid,
-                lecture,
-                lab,
-                tutorial,
-                selected,
-                showSections,
-                color,
-              };
+            if (!cachedSections) {
+              const sections = await getSections({ term, subject, code });
+              SECTIONS_CACHE[key] = sections;
             }
-          )
+            // TODO: transform into calendar events :wink:
+
+            return {
+              sections: SECTIONS_CACHE[key],
+              term,
+              subject,
+              code,
+              pid,
+              lecture,
+              lab,
+              tutorial,
+              selected,
+              color,
+            };
+          })
         );
         setResult({ status: 'loaded', data: coursesSections });
       } catch (e) {


### PR DESCRIPTION
Closes #279

Because showSections was a property of each course saved in LocalStorage, when the dropdown menu was opened, the stored course data would change, triggering a re-render of the whole calendar and resetting the week view.

I removed the showSections property of the saved courses, replacing it with a state variable in the CourseCard component. I also added a useEffect hook to make it so the sections are shown when the course is added and to collapse it when the course is removed from the timetable.

Because the showSections variable is no longer in the context of the SchedulerSidebar, I moved the SectionsCardContainer to be a child of CourseCard.

After I did this, I realized that in CourseCard, the checkbox's onChange event was getting fired when the sections menu was toggled, or when clicking anywhere on the card. I finally realized that the label prop of a parent Flex was the issue, so I removed it. I also removed the `cursor="pointer"` prop to show the users that clicking on the card itself does nothing.

## Checklist

- [x] The code follows all style guidelines.
- [x] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.