### PR TITLE
fix: Dynamic schedule not working for courses ending at 8

### DIFF
--- a/src/pages/scheduler/components/SchedulerCalendar.tsx
+++ b/src/pages/scheduler/components/SchedulerCalendar.tsx
@@ -167,7 +167,7 @@ export const SchedulerCalendar = ({ term, courseCalendarEvents = [] }: Scheduler
           const endDate = new Date(ruleLowerAll[i].toUTCString().replace('GMT', ''));
 
           const endHour = endDate.getHours();
-          if (endHour > maxHour) {
+          if (endHour >= maxHour) {
             setMaxHour(endHour + 1);
           }
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change(s) and which issue is being fixed. Please provide as much detail as possible. -->

The dynamic schedule fix was rolled out, however courses which ended _exactly_ at the default "max" hour were not kicking in the changes to make the schedule grow, making them cut off. This fixes that.

## Screenshots
<!-- Delete this section if changes do not require screenshots -->

<!-- Include any relevant screenshots or gifs to all frontend changes when applicable. -->

### Before
<!-- Add before screenshots when applicable. -->
![Screenshot from 2021-10-06 18-45-26](https://user-images.githubusercontent.com/53020925/136307646-ef6a1109-2ea3-4c63-be14-b1a9e817714c.png)


### After
<!-- Add after screenshots when applicable. -->
![Screenshot from 2021-10-06 18-44-50](https://user-images.githubusercontent.com/53020925/136307644-803ea786-53dd-4759-a94e-61faa31f8547.png)
## Checklist

- [x] The code follows all style guidelines.
- [ ] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
