### PR TITLE
fix: Default term functions

### DIFF
--- a/src/lib/utils/__tests__/terms.test.ts
+++ b/src/lib/utils/__tests__/terms.test.ts
@@ -1,4 +1,4 @@
-import { getReadableTerm, getCurrentTerms, getCurrentTerm } from '../terms';
+import { getReadableTerm, getCurrentTerm } from '../terms';
 
 describe('term utils', () => {
   describe('getReadableTerm', () => {
@@ -26,48 +26,6 @@ describe('term utils', () => {
       });
       it('should return `Fall 1234`', () => {
         expect(getReadableTerm('123409')).toStrictEqual('Fall 1234');
-      });
-    });
-  });
-
-  describe('getCurrentTerms', () => {
-    describe('when passing in the date', () => {
-      it('should return the correct array', () => {
-        expect(getCurrentTerms(new Date('1999-12-09'))).toStrictEqual(['199905', '199909', '200001']);
-      });
-    });
-
-    describe('during the fall', () => {
-      it('should return `[202105, 202109, 202201] at the beginning of the term`', () => {
-        jest.useFakeTimers('modern').setSystemTime(new Date('2021-09-01').getTime());
-        expect(getCurrentTerms()).toStrictEqual(['202105', '202109', '202201']);
-      });
-
-      it('should return `[202105, 202109, 202201] in the middle of the term`', () => {
-        jest.useFakeTimers('modern').setSystemTime(new Date('2021-11-04').getTime());
-        expect(getCurrentTerms()).toStrictEqual(['202105', '202109', '202201']);
-      });
-
-      it('should return `[202205, 202209, 202301]`', () => {
-        jest.useFakeTimers('modern').setSystemTime(new Date('2022-12-31').getTime());
-        expect(getCurrentTerms()).toStrictEqual(['202205', '202209', '202301']);
-      });
-    });
-
-    describe('during the winter', () => {
-      it('should return `[202009, 202101, 202105] at the beginning of the term`', () => {
-        jest.useFakeTimers('modern').setSystemTime(new Date('January 1, 2021').getTime());
-        expect(getCurrentTerms()).toStrictEqual(['202009', '202101', '202105']);
-      });
-
-      it('should return `[202009, 202101, 202105] in the middle of the term`', () => {
-        jest.useFakeTimers('modern').setSystemTime(new Date('February 2, 2021').getTime());
-        expect(getCurrentTerms()).toStrictEqual(['202009', '202101', '202105']);
-      });
-
-      it('should return `[202109, 202201, 202205]`', () => {
-        jest.useFakeTimers('modern').setSystemTime(new Date('April 31, 2022').getTime());
-        expect(getCurrentTerms()).toStrictEqual(['202109', '202201', '202205']);
       });
     });
   });

--- a/src/lib/utils/terms.ts
+++ b/src/lib/utils/terms.ts
@@ -17,25 +17,6 @@ export function getReadableTerm(term: string): string {
 }
 
 /**
- * Fetches the current terms of a school year given a date.
- *
- * @param {Date} date
- * @return {string[]} array of terms ['202009', '202101', '202105']
- */
-export function getCurrentTerms(date: Date = new Date()): string[] {
-  const year = date.getFullYear();
-  const prevYear = date.getFullYear() - 1;
-  const nextYear = date.getFullYear() + 1;
-  const currMonth = date.getMonth();
-
-  if (0 <= currMonth && currMonth <= 4) {
-    return [`${prevYear}09`, `${year}01`, `${year}05`];
-  } else {
-    return [`${year}05`, `${year}09`, `${nextYear}01`];
-  }
-}
-
-/**
  * Fetches the current term given a date.
  *
  * @param {Date} date


### PR DESCRIPTION
# Description
Term functions were messed up and not defaulting to the right term. Fixed it so now it should default to Fall when users select timetable or courses during the fall semester instead of summer.
<!-- Please include a summary of the change(s) and which issue is being fixed. Please provide as much detail as possible. -->
Messed up the logic in the functions where the default term was determined. Fixed it here.
<!-- Replace `XX` with the concerning issue number. -->
Closes #XX

## Checklist

- [x] The code follows all style guidelines.
- [x] The code passes all required tests.
- [x] The code is documented.
- [x] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
