### PR TITLE
fix: make calendar events cache key more unique

### DIFF
--- a/src/pages/scheduler/components/SchedulerCalendar.tsx
+++ b/src/pages/scheduler/components/SchedulerCalendar.tsx
@@ -19,6 +19,9 @@ import { CourseCalendarEvent } from '../shared/types';
 
 const EVENTS_CACHE: { [key: string]: ParseMeetingTimesResult } = {};
 
+const buildEventsCacheKey = (event: CourseCalendarEvent) =>
+  `${event.term}_${event.subject}_${event.code}_${event.sectionCode}_${event.meetingTime.days}_${event.meetingTime.time}`;
+
 const localizer = dateFnsLocalizer({
   format,
   parse,
@@ -144,7 +147,7 @@ export const SchedulerCalendar = ({ term, courseCalendarEvents = [] }: Scheduler
     const events: CustomEvent[] = [];
     courseCalendarEvents.forEach((calendarEvent) => {
       // for caching purposes
-      const key = `${calendarEvent.term}_${calendarEvent.subject}_${calendarEvent.code}_${calendarEvent.sectionCode}`;
+      const key = buildEventsCacheKey(calendarEvent);
 
       try {
         // if event does not have a scheduled time, move on.


### PR DESCRIPTION
# Description
Fixes the events cache key not being unique for classes with multiple time slots for a given section.
<!-- Please include a summary of the change(s) and which issue is being fixed. Please provide as much detail as possible. -->
This fix is implemented by building the cache key with the meeting days and time appended to the existing one.

<!-- Replace `XX` with the concerning issue number. -->
Closes #296 

## Screenshots
<!-- Delete this section if changes do not require screenshots -->

<!-- Include any relevant screenshots or gifs to all frontend changes when applicable. -->

### Before
<!-- Add before screenshots when applicable. -->
<img width="1121" alt="" src="https://user-images.githubusercontent.com/1757744/139012614-466de86a-b979-47d4-b989-98c80313bc9b.png">

### After
<!-- Add after screenshots when applicable. -->
![image](https://user-images.githubusercontent.com/1757744/139012692-609c8f39-8895-4b69-bcdd-e5a8bc1eb032.png)

## Checklist

- [x] The code follows all style guidelines.
- [x] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
