### PR TITLE
fix(terms): Change winter term to spring

### DIFF
--- a/src/lib/utils/__tests__/terms.test.ts
+++ b/src/lib/utils/__tests__/terms.test.ts
@@ -11,12 +11,12 @@ describe('term utils', () => {
       });
     });
 
-    describe('winter terms', () => {
-      it('should return `Winter 2021`', () => {
-        expect(getReadableTerm('202101')).toStrictEqual('Winter 2021');
+    describe('spring terms', () => {
+      it('should return `Spring 2021`', () => {
+        expect(getReadableTerm('202101')).toStrictEqual('Spring 2021');
       });
-      it('should return `Winter 3001`', () => {
-        expect(getReadableTerm('300101')).toStrictEqual('Winter 3001');
+      it('should return `Spring 3001`', () => {
+        expect(getReadableTerm('300101')).toStrictEqual('Spring 3001');
       });
     });
 
@@ -44,7 +44,7 @@ describe('term utils', () => {
       });
     });
 
-    describe('during the winter', () => {
+    describe('during the spring', () => {
       it('should return 202101', () => {
         jest.useFakeTimers('modern').setSystemTime(new Date('March 16, 2021').getTime());
         expect(getCurrentTerm()).toStrictEqual('202101');

--- a/src/lib/utils/terms.ts
+++ b/src/lib/utils/terms.ts
@@ -9,7 +9,7 @@ export function getReadableTerm(term: string): string {
   const year = term.slice(0, 4);
   let month = term.slice(4);
 
-  if (month === '01') month = 'Winter';
+  if (month === '01') month = 'Spring';
   else if (month === '05') month = 'Summer';
   else month = 'Fall';
 


### PR DESCRIPTION
# Description
By UVic definition, the semester from January-April is technically called the "Spring" semester, which we have been calling "Winter". Changed that in this PR.

<!-- Please include a summary of the change(s) and which issue is being fixed. Please provide as much detail as possible. -->

<!-- Replace `XX` with the concerning issue number. -->
Closes #XX

## Screenshots
<!-- Delete this section if changes do not require screenshots -->

<!-- Include any relevant screenshots or gifs to all frontend changes when applicable. -->

### Before
<!-- Add before screenshots when applicable. -->

### After
<!-- Add after screenshots when applicable. -->

## Checklist

- [x] The code follows all style guidelines.
- [x] The code passes all required tests.
- [ ] The code is documented.
- [x] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
