### PR TITLE
feat: allow loading in other terms for textbooks

### DIFF
--- a/.github/workflows/populate-textbooks.yaml
+++ b/.github/workflows/populate-textbooks.yaml
@@ -5,6 +5,9 @@ on:
       environment:
         description: Application environment to execute in.
         required: true
+      term:
+        description: Academic term to execute descript with. ie 202009, 202001
+        required: true
 jobs:
   lint:
     name: Lint
@@ -58,4 +61,4 @@ jobs:
           service_account_key: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           export_default_credentials: true
       - name: Execute Script
-        run: npm run db:textbooks
+        run: npm run db:textbooks ${{ github.event.inputs.term }}

--- a/functions/scripts/populate-textbooks.ts
+++ b/functions/scripts/populate-textbooks.ts
@@ -15,7 +15,12 @@ if (process.env.FIRESTORE_EMULATOR_HOST) {
   admin.initializeApp({ credential: admin.credential.applicationDefault() });
 }
 
-const term = '202109';
+if (process.argv.length != 3) throw Error('Term argument not found.');
+
+const term = process.argv[2];
+
+if (!/20\d{2}0[1,5,9]/.test(term.trim()))
+  throw Error('Invalid term argument format');
 
 const main = async () => {
   const courses = await got(


### PR DESCRIPTION
# Description
A simple PR to allow the term to be passed in as an argument rather than be hardcoded to a specific term. The GitHub action will now have a term input option.

The button itself will need to be enabled after we can verify the data is loaded in properly. This can be bypassed by just going directly to the page.

## Checklist

- [x] The code follows all style guidelines.
- [ ] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
