### PR TITLE
fix: booklist term and README logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="public/assets/logo/png/CourseUp-Logo-With-Wordmark.png" height="75px">
+# CourseUp
 
 [![Contributors][contributors-shield]][contributors-link]
 [![Stargazers][stars-shield]][stars-link]

--- a/src/pages/booklist/components/BooklistHeading.tsx
+++ b/src/pages/booklist/components/BooklistHeading.tsx
@@ -5,24 +5,25 @@ import { getReadableTerm } from 'lib/utils/terms';
 
 export function BooklistHeading() {
   const { term } = useParams();
+  const readableTerm = getReadableTerm(term);
 
   return (
     <Container alignItems="center" maxW="container.xl">
       <HStack>
         <Center direction={{ md: 'row', base: 'column' }} alignItems="center" w="100%">
           <Heading fontSize={{ base: '1.5rem', md: '2.15rem' }} as="h1" marginBottom={{ base: '1rem', md: '0' }}>
-            Booklist for {`${getReadableTerm(term)}`}
+            Booklist for {readableTerm}
           </Heading>
         </Center>
       </HStack>
       <Divider my="4" />
       <Flex direction="column">
         <Text w="100%" textAlign="left">
-          The following is a booklist for the <Text as="strong">Fall 2021 </Text>term compiled from the saved courses on
-          your timetable. Please note that this feature is still in <Text as="strong">beta</Text>. Please feel free to
-          provide any feedback or report bugs via the <Text as="strong">Feedback Button</Text> at the bottom right of
-          your screen! Purchases made through store links may provide compensation to CourseUp and VikeLabs. This helps
-          keep the platform free of ads and supports development.
+          The following is a booklist for the <Text as="strong">{readableTerm} </Text>term compiled from the saved
+          courses on your timetable. Please note that this feature is still in <Text as="strong">beta</Text>. Please
+          feel free to provide any feedback or report bugs via the <Text as="strong">Feedback Button</Text> at the
+          bottom right of your screen! Purchases made through store links may provide compensation to CourseUp and
+          VikeLabs. This helps keep the platform free of ads and supports development.
         </Text>
       </Flex>
     </Container>


### PR DESCRIPTION
# Description
Fixes that the term is hardcoded and the WIP branding is left in the README file.
## Screenshots

### Before
<!-- Add before screenshots when applicable. -->
![image](https://user-images.githubusercontent.com/1757744/148858721-f4e38f0f-7025-4f81-8819-5fded780b119.png)

### After
<!-- Add after screenshots when applicable. -->
![image](https://user-images.githubusercontent.com/1757744/148858707-1b675896-14ba-4f44-983a-bda5cccbf78b.png)

## Checklist

- [x] The code follows all style guidelines.
- [x] The code passes all required tests.
- [x] The code is documented.
- [ ] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
