### PR TITLE
feat: textbook and calendar download tracking

### DIFF
--- a/src/lib/hooks/useSavedCourses.ts
+++ b/src/lib/hooks/useSavedCourses.ts
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
+import { logEvent } from 'index';
 import _ from 'lodash';
 
 import { getSections } from 'lib/api/getSections';
@@ -72,6 +73,16 @@ export const useSavedCourses = (): SavedCourses => {
   // The underlying data persistent storage.
   const [data, setData] = useLocalStorage<SavedCourse[]>('user:saved_courses', []);
 
+  useEffect(() => {
+    data.forEach((course) => {
+      logEvent('saved_course', {
+        subject: course.subject,
+      });
+    });
+    // only want to run once.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const containsColor = useCallback(
     (color: string, term: string): boolean => data.some((course) => course.color === color && course.term === term),
     [data]
@@ -119,6 +130,10 @@ export const useSavedCourses = (): SavedCourses => {
     (term: string, subject: string, code: string, pid: string) => {
       // avoid adding a course if it is saved already.
       if (contains(pid, term)) return;
+
+      logEvent('saved_course', {
+        subject,
+      });
 
       const course: SavedCourse = { term, subject, code, pid, selected: true, showSections: true };
       // we need to load in the course sections given we have no idea which default sections to select

--- a/src/pages/booklist/components/Textbook.tsx
+++ b/src/pages/booklist/components/Textbook.tsx
@@ -14,6 +14,7 @@ import {
   VStack,
   Image,
 } from '@chakra-ui/react';
+import { logEvent } from 'index';
 import { IoBook } from 'react-icons/io5';
 
 import { useDarkMode } from 'lib/hooks/useDarkMode';
@@ -43,6 +44,10 @@ export function Textbook({
   amazonUrl,
 }: Props) {
   const mode = useDarkMode();
+
+  const handleTextbookClick = (url?: string) => {
+    url && logEvent('textbook_click', { url });
+  };
 
   return (
     <Flex alignItems="center" direction={{ base: 'column', md: 'row' }} mt="1">
@@ -117,6 +122,7 @@ export function Textbook({
           colorScheme="blue"
           rightIcon={<LinkIcon />}
           disabled={bookstoreUrl === undefined}
+          onClick={() => handleTextbookClick(bookstoreUrl)}
           as="a"
           href={bookstoreUrl}
           target="_blank"
@@ -131,6 +137,7 @@ export function Textbook({
           href={amazonUrl}
           target="_blank"
           disabled={amazonUrl === undefined}
+          onClick={() => handleTextbookClick(amazonUrl)}
         >
           <Image
             loading="lazy"

--- a/src/pages/booklist/containers/BooklistContainer.tsx
+++ b/src/pages/booklist/containers/BooklistContainer.tsx
@@ -23,7 +23,7 @@ export function BooklistContainer(): JSX.Element | null {
   const textbooks = useTextbooks(term as Term);
 
   useEffect(() => {
-    logEvent('textbooks', { term });
+    logEvent('textbooks_view', { term });
   }, [term]);
 
   return (

--- a/src/pages/booklist/containers/BooklistContainer.tsx
+++ b/src/pages/booklist/containers/BooklistContainer.tsx
@@ -1,5 +1,8 @@
+import { useEffect } from 'react';
+
 import { Box, Container, Divider, Flex, Heading } from '@chakra-ui/layout';
 import { Center, Spinner, Text } from '@chakra-ui/react';
+import { logEvent } from 'index';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router';
 
@@ -18,6 +21,10 @@ export function BooklistContainer(): JSX.Element | null {
   const mode = useDarkMode();
 
   const textbooks = useTextbooks(term as Term);
+
+  useEffect(() => {
+    logEvent('textbooks', { term });
+  }, [term]);
 
   return (
     <Flex h="100vh" direction="column" overflowX="hidden" overflowY="hidden">

--- a/src/pages/scheduler/components/Toolbar.tsx
+++ b/src/pages/scheduler/components/Toolbar.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons';
 import { Button, Flex, Heading, HStack, IconButton, Text } from '@chakra-ui/react';
+import { logEvent } from 'index';
 import { ToolbarProps } from 'react-big-calendar';
 
 export const CalendarToolBar =
@@ -17,6 +18,8 @@ export const CalendarToolBar =
 
     const handleDownload = () => {
       if (vCalendar) {
+        logEvent('calendar_download', { term });
+
         const element = document.createElement('a');
         const file = new Blob([vCalendar], { type: 'text/plain' });
         element.href = URL.createObjectURL(file);


### PR DESCRIPTION
# Description
This PR adds event tracking using Google Analytics for the following events
- When a user views the textbooks page.
- When a user clicks on a textbook url, the url is the event payload
- When a user loads their saved courses the subject of each course is as the payload
- When a user adds a course to their saved courses, the subject of that course is the payload.
- When a user downloads their schedule.

Any events without a payload are simply an event without any additional metadata (ie. it happened)

The primary motivation of tracking these events is to gain an understanding which features are being used and what the overall picture is in regards to the subjects of courses. This will allow a loose understanding of faculty adoption of the application.

This data will be used to bolster advertising efforts by determining which faculties we need to focus on. This data is not used to profile users for the sake of serving ads to users of the CourseUp platform already.
## Checklist

- [ ] The code follows all style guidelines.
- [ ] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [ ] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
