### PR TITLE
feat: Mobile calendar visual fixes

### DIFF
--- a/src/pages/import/components/ImportCalendar.tsx
+++ b/src/pages/import/components/ImportCalendar.tsx
@@ -6,6 +6,7 @@ import { Box } from '@chakra-ui/layout';
 
 import { Timetable } from 'lib/fetchers';
 import { SavedCourse } from 'lib/hooks/useSavedCourses';
+import { getCurrentTerm } from 'lib/utils/terms';
 
 import { SchedulerCalendar } from 'pages/scheduler/components/SchedulerCalendar';
 import { useGetCourseSections } from 'pages/scheduler/hooks/useCalendarEvents';
@@ -43,7 +44,7 @@ export const ImportCalendar = ({ timetableCourses }: { timetableCourses: Timetab
 
   return (
     <Box w="100%" px="3" pb="14" h="100%">
-      <SchedulerCalendar term={term} courseCalendarEvents={calendarEvents} />
+      <SchedulerCalendar term={term || getCurrentTerm()} courseCalendarEvents={calendarEvents} />
     </Box>
   );
 };

--- a/src/pages/import/index.tsx
+++ b/src/pages/import/index.tsx
@@ -78,9 +78,7 @@ export function ImportTimetable(): JSX.Element {
               <Button isActive={!calendarView} onClick={() => setCalendarView(false)}>
                 List
               </Button>
-              <Button isDisabled onClick={() => setCalendarView(true)}>
-                Calendar
-              </Button>
+              <Button onClick={() => setCalendarView(true)}>Calendar</Button>
             </ButtonGroup>
           </HStack>
           <Box w="100%">

--- a/src/pages/scheduler/components/CourseCard.tsx
+++ b/src/pages/scheduler/components/CourseCard.tsx
@@ -119,13 +119,7 @@ export function CourseCard({
             />
             <IconButton
               aria-label="More information"
-              icon={
-                showSections ? (
-                  <ChevronUpIcon color="white" boxSize="1.5em" />
-                ) : (
-                  <ChevronDownIcon color="white" boxSize="1.5em" />
-                )
-              }
+              icon={showSections ? <ChevronUpIcon boxSize="1.5em" /> : <ChevronDownIcon boxSize="1.5em" />}
               colorScheme="blue"
               size="xs"
               onClick={onShowSections}

--- a/src/pages/scheduler/components/SchedulerCalendar.tsx
+++ b/src/pages/scheduler/components/SchedulerCalendar.tsx
@@ -11,7 +11,7 @@ import { useDarkMode } from 'lib/hooks/useDarkMode';
 import { getCurrentTerm } from 'lib/utils/terms';
 
 import { CalendarEvent } from 'pages/scheduler/components/Event';
-import { CalendarToolBar } from 'pages/scheduler/components/Toolbar';
+import { CalendarToolBar, MobileToolBar } from 'pages/scheduler/components/Toolbar';
 import { useInitialDateTime } from 'pages/scheduler/hooks/useInitialDatetime';
 import { coursesToVCalendar } from 'pages/scheduler/shared/exporter';
 import { courseCalEventsToCustomEvents } from 'pages/scheduler/shared/transformers';
@@ -83,7 +83,9 @@ export const SchedulerCalendar = ({ term, courseCalendarEvents = [] }: Scheduler
       eventPropGetter={eventPropGetter}
       slotPropGetter={slotPropGetter(mode)}
       components={{
-        toolbar: CalendarToolBar(setSelectedDate, term || getCurrentTerm(), vCalendar),
+        toolbar: isMobile
+          ? MobileToolBar(setSelectedDate, term || getCurrentTerm(), vCalendar)
+          : CalendarToolBar(setSelectedDate, term || getCurrentTerm(), vCalendar),
         event: CalendarEvent,
       }}
       dayLayoutAlgorithm="no-overlap"

--- a/src/pages/scheduler/components/SchedulerCalendar.tsx
+++ b/src/pages/scheduler/components/SchedulerCalendar.tsx
@@ -11,7 +11,7 @@ import { useDarkMode } from 'lib/hooks/useDarkMode';
 import { getCurrentTerm } from 'lib/utils/terms';
 
 import { CalendarEvent } from 'pages/scheduler/components/Event';
-import { CalendarToolBar, MobileToolBar } from 'pages/scheduler/components/Toolbar';
+import { CalendarToolBar } from 'pages/scheduler/components/Toolbar';
 import { useInitialDateTime } from 'pages/scheduler/hooks/useInitialDatetime';
 import { coursesToVCalendar } from 'pages/scheduler/shared/exporter';
 import { courseCalEventsToCustomEvents } from 'pages/scheduler/shared/transformers';
@@ -52,6 +52,9 @@ export const SchedulerCalendar = ({ term, courseCalendarEvents = [] }: Scheduler
   const [maxTime, setMaxTime] = useState<{ hours: number; minutes: number }>({ hours: 20, minutes: 0 });
 
   // create events compatible with the calendar from courses
+
+  const userCurrentTerm = term || getCurrentTerm();
+
   const vCalendar = useMemo(() => {
     return courseCalendarEvents.length !== 0 ? coursesToVCalendar(courseCalendarEvents) : undefined;
   }, [courseCalendarEvents]);
@@ -83,9 +86,7 @@ export const SchedulerCalendar = ({ term, courseCalendarEvents = [] }: Scheduler
       eventPropGetter={eventPropGetter}
       slotPropGetter={slotPropGetter(mode)}
       components={{
-        toolbar: isMobile
-          ? MobileToolBar(setSelectedDate, term || getCurrentTerm(), vCalendar)
-          : CalendarToolBar(setSelectedDate, term || getCurrentTerm(), vCalendar),
+        toolbar: CalendarToolBar(setSelectedDate, userCurrentTerm, isMobile, vCalendar),
         event: CalendarEvent,
       }}
       dayLayoutAlgorithm="no-overlap"

--- a/src/pages/scheduler/components/SchedulerCalendar.tsx
+++ b/src/pages/scheduler/components/SchedulerCalendar.tsx
@@ -8,7 +8,6 @@ import { enUS } from 'date-fns/locale';
 import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
 
 import { useDarkMode } from 'lib/hooks/useDarkMode';
-import { getCurrentTerm } from 'lib/utils/terms';
 
 import { CalendarEvent } from 'pages/scheduler/components/Event';
 import { CalendarToolBar } from 'pages/scheduler/components/Toolbar';
@@ -35,7 +34,7 @@ export interface SchedulerCalendarProps {
    * Parses events that can go into the calendar from this
    */
   courseCalendarEvents?: CourseCalendarEvent[];
-  term?: string;
+  term: string;
 }
 
 export const SchedulerCalendar = ({ term, courseCalendarEvents = [] }: SchedulerCalendarProps): JSX.Element => {
@@ -52,8 +51,6 @@ export const SchedulerCalendar = ({ term, courseCalendarEvents = [] }: Scheduler
   const [maxTime, setMaxTime] = useState<{ hours: number; minutes: number }>({ hours: 20, minutes: 0 });
 
   // create events compatible with the calendar from courses
-
-  const userCurrentTerm = term || getCurrentTerm();
 
   const vCalendar = useMemo(() => {
     return courseCalendarEvents.length !== 0 ? coursesToVCalendar(courseCalendarEvents) : undefined;
@@ -86,7 +83,7 @@ export const SchedulerCalendar = ({ term, courseCalendarEvents = [] }: Scheduler
       eventPropGetter={eventPropGetter}
       slotPropGetter={slotPropGetter(mode)}
       components={{
-        toolbar: CalendarToolBar(setSelectedDate, userCurrentTerm, isMobile, vCalendar),
+        toolbar: CalendarToolBar(setSelectedDate, term, isMobile, vCalendar),
         event: CalendarEvent,
       }}
       dayLayoutAlgorithm="no-overlap"

--- a/src/pages/scheduler/components/Toolbar.tsx
+++ b/src/pages/scheduler/components/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons';
+import { ChevronLeftIcon, ChevronRightIcon, DownloadIcon } from '@chakra-ui/icons';
 import { Button, Flex, HStack, IconButton, Text } from '@chakra-ui/react';
 import { ToolbarProps } from 'react-big-calendar';
 
@@ -6,6 +6,69 @@ import { Term } from 'lib/fetchers';
 import { logEvent } from 'lib/utils/logEvent';
 
 import { ShareButton } from './share/ShareButton';
+
+export const MobileToolBar =
+  (onSelectedDateChange: (date: Date) => void, term: string, vCalendar?: string) =>
+  ({ label, date }: ToolbarProps) => {
+    const handleClick = (offset?: number) => () => {
+      if (offset) {
+        const d = new Date(date);
+        d.setDate(d.getDate() + offset);
+        onSelectedDateChange(d);
+      } else {
+        onSelectedDateChange(new Date());
+      }
+    };
+
+    console.log(date);
+
+    const handleDownload = () => {
+      if (vCalendar) {
+        logEvent('calendar_download', { term });
+
+        const element = document.createElement('a');
+        const file = new Blob([vCalendar], { type: 'text/plain' });
+        element.href = URL.createObjectURL(file);
+        element.download = `${term}_calendar.ics`;
+        element.click();
+        document.body.removeChild(element);
+      }
+    };
+
+    return (
+      <Flex pb="0.5em" justifyContent="space-between" alignItems="center">
+        <Text fontSize="xs">{label}</Text>
+        <HStack pb="0.2em">
+          <ShareButton term={term as Term} disabled={!vCalendar} />
+          <IconButton
+            icon={<DownloadIcon />}
+            aria-label="Download timetable"
+            size="sm"
+            colorScheme="blue"
+            onClick={handleDownload}
+            disabled={!vCalendar}
+          />
+          <Button size="sm" colorScheme="gray" onClick={handleClick()}>
+            Today
+          </Button>
+          <IconButton
+            aria-label="Previous day"
+            colorScheme="gray"
+            icon={<ChevronLeftIcon />}
+            size="sm"
+            onClick={handleClick(-1)}
+          />
+          <IconButton
+            aria-label="Next day"
+            colorScheme="gray"
+            icon={<ChevronRightIcon />}
+            size="sm"
+            onClick={handleClick(1)}
+          />
+        </HStack>
+      </Flex>
+    );
+  };
 
 export const CalendarToolBar =
   (onSelectedDateChange: (date: Date) => void, term: string, vCalendar?: string) =>

--- a/src/pages/scheduler/components/Toolbar.tsx
+++ b/src/pages/scheduler/components/Toolbar.tsx
@@ -7,71 +7,8 @@ import { logEvent } from 'lib/utils/logEvent';
 
 import { ShareButton } from './share/ShareButton';
 
-export const MobileToolBar =
-  (onSelectedDateChange: (date: Date) => void, term: string, vCalendar?: string) =>
-  ({ label, date }: ToolbarProps) => {
-    const handleClick = (offset?: number) => () => {
-      if (offset) {
-        const d = new Date(date);
-        d.setDate(d.getDate() + offset);
-        onSelectedDateChange(d);
-      } else {
-        onSelectedDateChange(new Date());
-      }
-    };
-
-    console.log(date);
-
-    const handleDownload = () => {
-      if (vCalendar) {
-        logEvent('calendar_download', { term });
-
-        const element = document.createElement('a');
-        const file = new Blob([vCalendar], { type: 'text/plain' });
-        element.href = URL.createObjectURL(file);
-        element.download = `${term}_calendar.ics`;
-        element.click();
-        document.body.removeChild(element);
-      }
-    };
-
-    return (
-      <Flex pb="0.5em" justifyContent="space-between" alignItems="center">
-        <Text fontSize="xs">{label}</Text>
-        <HStack pb="0.2em">
-          <ShareButton term={term as Term} disabled={!vCalendar} />
-          <IconButton
-            icon={<DownloadIcon />}
-            aria-label="Download timetable"
-            size="sm"
-            colorScheme="blue"
-            onClick={handleDownload}
-            disabled={!vCalendar}
-          />
-          <Button size="sm" colorScheme="gray" onClick={handleClick()}>
-            Today
-          </Button>
-          <IconButton
-            aria-label="Previous day"
-            colorScheme="gray"
-            icon={<ChevronLeftIcon />}
-            size="sm"
-            onClick={handleClick(-1)}
-          />
-          <IconButton
-            aria-label="Next day"
-            colorScheme="gray"
-            icon={<ChevronRightIcon />}
-            size="sm"
-            onClick={handleClick(1)}
-          />
-        </HStack>
-      </Flex>
-    );
-  };
-
 export const CalendarToolBar =
-  (onSelectedDateChange: (date: Date) => void, term: string, vCalendar?: string) =>
+  (onSelectedDateChange: (date: Date) => void, term: string, isMobile: boolean, vCalendar?: string) =>
   ({ label, date }: ToolbarProps) => {
     const handleClick = (offset?: number) => () => {
       if (offset) {
@@ -98,12 +35,23 @@ export const CalendarToolBar =
 
     return (
       <Flex pb="0.5em" justifyContent="space-between" alignItems="center">
-        <Text fontSize="xl">{label}</Text>
+        <Text fontSize={{ base: 'xs', sm: 'xl' }}>{label}</Text>
         <HStack pb="0.2em">
           <ShareButton term={term as Term} disabled={!vCalendar} />
-          <Button size="sm" colorScheme="blue" onClick={handleDownload} disabled={!vCalendar}>
-            Download
-          </Button>
+          {isMobile ? (
+            <IconButton
+              icon={<DownloadIcon />}
+              aria-label="Download timetable"
+              size="sm"
+              colorScheme="blue"
+              onClick={handleDownload}
+              disabled={!vCalendar}
+            />
+          ) : (
+            <Button size="sm" colorScheme="blue" onClick={handleDownload} disabled={!vCalendar}>
+              Download
+            </Button>
+          )}
           <Button size="sm" colorScheme="gray" onClick={handleClick()}>
             Today
           </Button>
@@ -112,14 +60,14 @@ export const CalendarToolBar =
             colorScheme="gray"
             icon={<ChevronLeftIcon />}
             size="sm"
-            onClick={handleClick(-7)}
+            onClick={handleClick(isMobile ? -1 : -7)}
           />
           <IconButton
             aria-label="Next Week"
             colorScheme="gray"
             icon={<ChevronRightIcon />}
             size="sm"
-            onClick={handleClick(7)}
+            onClick={handleClick(isMobile ? 1 : 7)}
           />
         </HStack>
       </Flex>

--- a/src/pages/scheduler/components/share/ShareButton.tsx
+++ b/src/pages/scheduler/components/share/ShareButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Button, Icon, useDisclosure } from '@chakra-ui/react';
+import { Button, Icon, IconButton, useDisclosure, useMediaQuery } from '@chakra-ui/react';
 import { IoShareOutline } from 'react-icons/io5';
 import { useMatch } from 'react-router';
 
@@ -11,7 +11,7 @@ import ShareTimetableModal from './ShareTimetableModal';
 
 export function ShareButton({ term, disabled }: { term: Term; disabled: boolean }): JSX.Element | null {
   const importPage = useMatch('/s/:slug');
-
+  const [isMobile] = useMediaQuery('(max-width: 1020px)');
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   // gets saved courses in session to enable/disable share button accordingly
@@ -52,15 +52,26 @@ export function ShareButton({ term, disabled }: { term: Term; disabled: boolean 
     <></>
   ) : (
     <>
-      <Button
-        disabled={disabled}
-        size="sm"
-        colorScheme="purple"
-        leftIcon={<Icon as={IoShareOutline} />}
-        onClick={handleShare}
-      >
-        Share
-      </Button>
+      {isMobile ? (
+        <IconButton
+          aria-label="Share timetable"
+          icon={<IoShareOutline />}
+          disabled={disabled}
+          size="sm"
+          colorScheme="purple"
+          onClick={handleShare}
+        />
+      ) : (
+        <Button
+          disabled={disabled}
+          size="sm"
+          colorScheme="purple"
+          leftIcon={<Icon as={IoShareOutline} />}
+          onClick={handleShare}
+        >
+          Share
+        </Button>
+      )}
       <ShareTimetableModal
         term={term}
         loading={loading}

--- a/src/pages/scheduler/containers/SchedulerContainer.tsx
+++ b/src/pages/scheduler/containers/SchedulerContainer.tsx
@@ -4,6 +4,7 @@ import { Box, Flex } from '@chakra-ui/react';
 import { useParams } from 'react-router';
 
 import { useSavedCourses } from 'lib/hooks/useSavedCourses';
+import { getCurrentTerm } from 'lib/utils/terms';
 
 import { SchedulerCalendar } from '../components/SchedulerCalendar';
 import { useGetCourseSections } from '../hooks/useCalendarEvents';
@@ -24,7 +25,7 @@ export function SchedulerContainer(): JSX.Element {
   return (
     <Flex grow={1} height="100%" overflow="hidden">
       <Box w="100%" height="100%" px="3" py="2">
-        <SchedulerCalendar term={term} courseCalendarEvents={calendarEvents} />
+        <SchedulerCalendar term={term || getCurrentTerm()} courseCalendarEvents={calendarEvents} />
       </Box>
     </Flex>
   );

--- a/src/pages/scheduler/styles/calendar.tsx
+++ b/src/pages/scheduler/styles/calendar.tsx
@@ -54,6 +54,7 @@ export const CalendarTheme = (colorMode: 'light' | 'dark'): CSSProperties => {
     },
 
     '.rbc-time-slot': {
+      bgColor: 'transparent !important',
       minH: '1.85em',
     },
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change(s) and which issue is being fixed. Please provide as much detail as possible. -->

<!-- Replace `XX` with the concerning issue number. -->
Fixes a visual bug where the times aren't visible on mobile calendars in light mode. Weirdest bug ever. Also made the toolbar responsive, so the calendar is usable in a read only mode. Enabled the calendar to be viewable from timetable sharing!

## Screenshots
<!-- Delete this section if changes do not require screenshots -->

<!-- Include any relevant screenshots or gifs to all frontend changes when applicable. -->

### Before
<!-- Add before screenshots when applicable. -->
<img width="375" alt="Screen Shot 2022-02-22 at 8 18 51 PM" src="https://user-images.githubusercontent.com/53020925/155261072-033bbc0a-3b98-4006-a3cb-6cfe3fd86272.png">

### After
<!-- Add after screenshots when applicable. -->
<img width="375" alt="Screen Shot 2022-02-22 at 8 18 32 PM" src="https://user-images.githubusercontent.com/53020925/155261051-61b10d37-8a5e-4723-b47e-38e6cf1b3168.png">

## Checklist

- [ ] The code follows all style guidelines.
- [ ] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [ ] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
