### PR TITLE
fix: Hide and Show showSections Toggle

### DIFF
--- a/src/pages/scheduler/components/CourseCard.tsx
+++ b/src/pages/scheduler/components/CourseCard.tsx
@@ -15,6 +15,7 @@ export type CourseCardProps = {
   pid: string;
   selected?: boolean;
   showSections?: boolean;
+  showSectionsToggle?: boolean;
   handleSelection: ({
     code,
     pid,
@@ -52,6 +53,7 @@ export function CourseCard({
   pid,
   selected,
   showSections,
+  showSectionsToggle,
   handleSelection,
   handleShowSections,
   handleDelete,
@@ -89,7 +91,7 @@ export function CourseCard({
             />
           </Flex>
         </Flex>
-        <Flex direction="row" alignItems="center" justifyContent="space-between" w="100%">
+        <Flex direction="row" alignItems="flex-start" justifyContent="space-between" w="100%">
           <Flex grow={1}>
             <VStack
               alignItems="start"
@@ -117,13 +119,15 @@ export function CourseCard({
               size="xs"
               onClick={onDelete}
             />
-            <IconButton
-              aria-label="More information"
-              icon={showSections ? <ChevronUpIcon boxSize="1.5em" /> : <ChevronDownIcon boxSize="1.5em" />}
-              colorScheme="blue"
-              size="xs"
-              onClick={onShowSections}
-            />
+            {showSectionsToggle && (
+              <IconButton
+                aria-label="More information"
+                icon={showSections ? <ChevronUpIcon boxSize="1.5em" /> : <ChevronDownIcon boxSize="1.5em" />}
+                colorScheme="blue"
+                size="xs"
+                onClick={onShowSections}
+              />
+            )}
           </VStack>
         </Flex>
       </Flex>

--- a/src/pages/scheduler/components/CourseCard.tsx
+++ b/src/pages/scheduler/components/CourseCard.tsx
@@ -15,7 +15,7 @@ export type CourseCardProps = {
   pid: string;
   selected?: boolean;
   showSections?: boolean;
-  showSectionsToggle?: boolean;
+  hasSections?: boolean;
   handleSelection: ({
     code,
     pid,
@@ -53,7 +53,7 @@ export function CourseCard({
   pid,
   selected,
   showSections,
-  showSectionsToggle,
+  hasSections,
   handleSelection,
   handleShowSections,
   handleDelete,
@@ -76,20 +76,32 @@ export function CourseCard({
   const { data, loading } = useGetCourse({ term: termTerm, pid });
 
   return (
-    <Box boxShadow="md" cursor="pointer" as="label" w="100%" bgColor={mode('white', 'dark.main')}>
+    <Box
+      boxShadow="md"
+      cursor={hasSections ? 'pointer' : 'default'}
+      as="label"
+      htmlFor={`checkbox-${pid}-${term}-${subject}-${code}`}
+      w="100%"
+      bgColor={mode('white', 'dark.main')}
+    >
       <Flex direction="row">
         <Flex background={color} alignItems="center" justifyContent="center" mr="10px">
-          <Flex>
-            <Checkbox
-              backgroundColor="whiteAlpha.600"
-              colorScheme="whiteAlpha"
-              iconColor="black"
-              size="lg"
-              mx="7px"
-              isChecked={selected}
-              onChange={onChange}
-            />
-          </Flex>
+          {hasSections ? (
+            <Flex>
+              <Checkbox
+                backgroundColor="whiteAlpha.600"
+                colorScheme="whiteAlpha"
+                iconColor="black"
+                id={`checkbox-${pid}-${term}-${subject}-${code}`}
+                size="lg"
+                mx="7px"
+                isChecked={selected}
+                onChange={onChange}
+              />
+            </Flex>
+          ) : (
+            <VStack mx="7px" width="5" />
+          )}
         </Flex>
         <Flex direction="row" alignItems="center" justifyContent="space-between" w="100%">
           <Flex grow={1}>
@@ -119,7 +131,7 @@ export function CourseCard({
               size="xs"
               onClick={onDelete}
             />
-            {showSectionsToggle && (
+            {hasSections && (
               <IconButton
                 aria-label="More information"
                 icon={showSections ? <ChevronUpIcon boxSize="1.5em" /> : <ChevronDownIcon boxSize="1.5em" />}

--- a/src/pages/scheduler/components/CourseCard.tsx
+++ b/src/pages/scheduler/components/CourseCard.tsx
@@ -91,7 +91,7 @@ export function CourseCard({
             />
           </Flex>
         </Flex>
-        <Flex direction="row" alignItems="flex-start" justifyContent="space-between" w="100%">
+        <Flex direction="row" alignItems="center" justifyContent="space-between" w="100%">
           <Flex grow={1}>
             <VStack
               alignItems="start"

--- a/src/pages/scheduler/components/SchedulerSidebar.tsx
+++ b/src/pages/scheduler/components/SchedulerSidebar.tsx
@@ -135,6 +135,7 @@ export function SchedulerSidebar({ term }: SchedulerSidebarProps): JSX.Element {
                   pid={course.pid}
                   selected={course.selected}
                   showSections={course.showSections !== undefined ? course.showSections : true}
+                  showSectionsToggle={course.sections.length > 0 ? true : false}
                   handleSelection={handleCourseToggle}
                   handleDelete={handleCourseDelete}
                   handleShowSections={handleShowSections}

--- a/src/pages/scheduler/components/SchedulerSidebar.tsx
+++ b/src/pages/scheduler/components/SchedulerSidebar.tsx
@@ -135,7 +135,7 @@ export function SchedulerSidebar({ term }: SchedulerSidebarProps): JSX.Element {
                   pid={course.pid}
                   selected={course.selected}
                   showSections={course.showSections !== undefined ? course.showSections : true}
-                  showSectionsToggle={course.sections.length > 0 ? true : false}
+                  hasSections={course.sections.length > 0}
                   handleSelection={handleCourseToggle}
                   handleDelete={handleCourseDelete}
                   handleShowSections={handleShowSections}


### PR DESCRIPTION
# Description

The showSections toggle appears on courses that do not have any sections. This can be confusing to people and make them think there is a bug. This PR proposes to hide the showSections toggle when no sections are available. 

I choose to hide instead of preventing user interaction to remove clutter.

Closes #347

## Screenshots

### Before
<img width="1341" alt="Capture d’écran, le 2022-03-11 à 07 48 36" src="https://user-images.githubusercontent.com/10472448/157901455-a326afa1-561c-41de-8378-4cf9212644ea.png">

### After
<img width="1343" alt="Capture d’écran, le 2022-03-11 à 07 49 26" src="https://user-images.githubusercontent.com/10472448/157901484-7aef6d14-7339-4d4d-87d3-55852663fbdb.png">

## Checklist

- [x] The code follows all style guidelines.
- [x] The code passes all required tests.
- [x] The code is documented.
- [ ] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.

## General Comments

I'm not sure if this is how you want to handle the toggle, let me know if you have another idea and the general approach that I should take.
