### PR TITLE
Show "Additional Notes" in Timetable view using Tooltip

### DIFF
--- a/src/pages/scheduler/components/SchedulerSections.tsx
+++ b/src/pages/scheduler/components/SchedulerSections.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 
-import { Radio, RadioGroup, Box, HStack, Text, VStack } from '@chakra-ui/react';
+import { Radio, RadioGroup, Box, HStack, Text, VStack, Tooltip, forwardRef } from '@chakra-ui/react';
 
 import { ClassScheduleListing, MeetingTimes } from 'lib/fetchers';
 import { useDarkMode } from 'lib/hooks/useDarkMode';
@@ -100,8 +100,13 @@ export function SectionGroup({ sections, type, course, courses, handleChange }: 
 
   return (
     <RadioGroup onChange={onChange} value={section} name={type}>
-      {filteredSections.map(({ sectionCode, meetingTimes }) => (
-        <Option sectionCode={sectionCode} meetingTimes={meetingTimes} key={sectionCode} />
+      {filteredSections.map(({ sectionCode, meetingTimes, additionalNotes }) => (
+        <Option
+          sectionCode={sectionCode}
+          meetingTimes={meetingTimes}
+          additionalNotes={additionalNotes}
+          key={sectionCode}
+        />
       ))}
     </RadioGroup>
   );
@@ -118,45 +123,53 @@ export interface OptionsProps {
    * example: A01, B01, T01 etc.
    */
   sectionCode: string;
+  /**
+   * Additional info like section restrictions, etc
+   */
+  additionalNotes?: string;
 }
 
-export function Option({ meetingTimes, sectionCode }: OptionsProps): JSX.Element {
-  const mode = useDarkMode();
+export const Option = forwardRef<OptionsProps, 'div'>(
+  ({ meetingTimes, sectionCode, additionalNotes }: OptionsProps, ref): JSX.Element => {
+    const mode = useDarkMode();
 
-  return (
-    <HStack
-      as="label"
-      px="3"
-      my="0.5"
-      fontSize="12px"
-      borderTop={mode('light.background', 'dark.background')}
-      borderTopWidth="2"
-      borderTopStyle="solid"
-    >
-      <HStack>
-        <Radio
-          value={sectionCode}
-          bgColor="white"
-          // HACK: position: sticky needed to fix issue with button click jumping position on page
-          position="sticky"
-        />
-        <Text as="strong">{sectionCode}</Text>
-      </HStack>
-      <VStack flexGrow={1} py="1.5">
-        {meetingTimes.map((m, key) => (
-          <HStack key={key} w="100%" px="5">
-            <Box w="33%" minW="27%">
-              {m.time.split('-').map((time) => (
-                <Text key={time}>{time}</Text>
-              ))}
-            </Box>
-            <Box w="20%" minW="13%">
-              {m.days}
-            </Box>
-            <Box w="47%">{m.where}</Box>
+    return (
+      <Tooltip label={additionalNotes} isDisabled={!additionalNotes} placement="left">
+        <HStack
+          as="label"
+          px="3"
+          my="0.5"
+          fontSize="12px"
+          borderTop={mode('light.background', 'dark.background')}
+          borderTopWidth="2"
+          borderTopStyle="solid"
+        >
+          <HStack ref={ref}>
+            <Radio
+              value={sectionCode}
+              bgColor="white"
+              // HACK: position: sticky needed to fix issue with button click jumping position on page
+              position="sticky"
+            />
+            <Text as="strong">{sectionCode}</Text>
           </HStack>
-        ))}
-      </VStack>
-    </HStack>
-  );
-}
+          <VStack flexGrow={1} py="1.5">
+            {meetingTimes.map((m, key) => (
+              <HStack key={key} w="100%" px="5">
+                <Box w="33%" minW="27%">
+                  {m.time.split('-').map((time) => (
+                    <Text key={time}>{time}</Text>
+                  ))}
+                </Box>
+                <Box w="20%" minW="13%">
+                  {m.days}
+                </Box>
+                <Box w="47%">{m.where}</Box>
+              </HStack>
+            ))}
+          </VStack>
+        </HStack>
+      </Tooltip>
+    );
+  }
+);

--- a/src/pages/scheduler/components/SchedulerSections.tsx
+++ b/src/pages/scheduler/components/SchedulerSections.tsx
@@ -136,7 +136,7 @@ export const Option = forwardRef<OptionsProps, 'div'>(
     const mode = useDarkMode();
 
     const truncAdditionalNotes =
-      additionalNotes?.length ?? 0 < maxAdditionalNotesLength
+      (additionalNotes?.length ?? 0) > maxAdditionalNotesLength
         ? additionalNotes?.substring(0, maxAdditionalNotesLength).trim() + '…'
         : additionalNotes;
 

--- a/src/pages/scheduler/components/SchedulerSections.tsx
+++ b/src/pages/scheduler/components/SchedulerSections.tsx
@@ -129,12 +129,19 @@ export interface OptionsProps {
   additionalNotes?: string;
 }
 
+const maxAdditionalNotesLength = 200;
+
 export const Option = forwardRef<OptionsProps, 'div'>(
   ({ meetingTimes, sectionCode, additionalNotes }: OptionsProps, ref): JSX.Element => {
     const mode = useDarkMode();
 
+    const truncAdditionalNotes =
+      additionalNotes?.length ?? 0 < maxAdditionalNotesLength
+        ? additionalNotes?.substring(0, maxAdditionalNotesLength).trim() + '…'
+        : additionalNotes;
+
     return (
-      <Tooltip label={additionalNotes} isDisabled={!additionalNotes} placement="left">
+      <Tooltip label={truncAdditionalNotes} isDisabled={!additionalNotes} placement="left">
         <HStack
           as="label"
           px="3"


### PR DESCRIPTION
# Description

This change displays the "Additional Info" text, also shown on the Calendar page, on the Timetable page as well. This info is displayed as a Chakra UI Tooltip, and is shown whenever you hover over the resulting section. When no "Additional Info" is present, no tooltip is shown.

As far as code goes, this change was trivial. `section.additionalNotes` was already present in the scope where `Option` was called, so I simply added it as a parameter. Inside of `Option`, I simply wrapped the entire contents in a tooltip.

Closes #354

## Screenshots

### Before

Nothing happens on hover

### After

https://user-images.githubusercontent.com/56709101/158445656-f78ddc9e-b06b-4c11-b5dd-b10a62305758.mp4

## Checklist

- [x] The code follows all style guidelines.
- [ ] The code passes all required tests.
- [x] The code is documented.
- [ ] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
