### PR TITLE
filter dropdown is now open permantently;

### DIFF
--- a/src/common/layouts/sidebar/variants/Courses.tsx
+++ b/src/common/layouts/sidebar/variants/Courses.tsx
@@ -90,7 +90,11 @@ export function CoursesTopBar({ onFilter }: TopBarProps): JSX.Element {
             <FormLabel htmlFor="email-alerts" mb="0" fontSize="sm">
               Only Show Courses in Session
             </FormLabel>
-            <Switch id="email-alerts" onChange={(e) => onFilter && onFilter(e.currentTarget.checked)} isChecked={filter} />
+            <Switch
+              id="email-alerts"
+              onChange={(e) => onFilter && onFilter(e.currentTarget.checked)}
+              isChecked={filter}
+            />
           </Flex>
         </FormControl>
       </Box>
@@ -107,7 +111,6 @@ type Props = {
 };
 
 export function Courses({ term }: Props): JSX.Element | null {
-  //const [filter, setFilter] = useState(false);
   const [filter, setFilter] = useSessionStorage<boolean>('filter_courses', true);
   const { data: subjects, loading: subjectsLoading } = useSubjects({ term: term as Term });
   const { data: courses, loading: coursesLoading } = useGetCourses({

--- a/src/common/layouts/sidebar/variants/Courses.tsx
+++ b/src/common/layouts/sidebar/variants/Courses.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { ChevronRightIcon } from '@chakra-ui/icons';
 import {
@@ -18,6 +18,7 @@ import { Route, Routes, useLocation, useParams } from 'react-router';
 import { Link, useSearchParams } from 'react-router-dom';
 
 import { Course, Term, useGetCourses, useSubjects } from 'lib/fetchers';
+import { useSessionStorage } from 'lib/hooks/storage/useSessionStorage';
 import { useDarkMode } from 'lib/hooks/useDarkMode';
 
 import { CoursesList } from '../components/CoursesList';
@@ -52,6 +53,7 @@ export function CoursesTopBar({ onFilter }: TopBarProps): JSX.Element {
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const mode = useDarkMode();
+  const [filter] = useSessionStorage<boolean>('filter_courses', true);
 
   const subject = location.pathname.split('/')[3];
   const route = location.pathname.split('/')[1];
@@ -88,7 +90,7 @@ export function CoursesTopBar({ onFilter }: TopBarProps): JSX.Element {
             <FormLabel htmlFor="email-alerts" mb="0" fontSize="sm">
               Only Show Courses in Session
             </FormLabel>
-            <Switch id="email-alerts" onChange={(e) => onFilter && onFilter(e.currentTarget.checked)} />
+            <Switch id="email-alerts" onChange={(e) => onFilter && onFilter(e.currentTarget.checked)} isChecked={filter} />
           </Flex>
         </FormControl>
       </Box>
@@ -105,7 +107,8 @@ type Props = {
 };
 
 export function Courses({ term }: Props): JSX.Element | null {
-  const [filter, setFilter] = useState(false);
+  //const [filter, setFilter] = useState(false);
+  const [filter, setFilter] = useSessionStorage<boolean>('filter_courses', true);
   const { data: subjects, loading: subjectsLoading } = useSubjects({ term: term as Term });
   const { data: courses, loading: coursesLoading } = useGetCourses({
     term: term as Term,

--- a/src/common/layouts/sidebar/variants/Courses.tsx
+++ b/src/common/layouts/sidebar/variants/Courses.tsx
@@ -5,14 +5,11 @@ import {
   Center,
   Box,
   Spinner,
-  useDisclosure,
   Flex,
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbLink,
   Text,
-  Button,
-  Collapse,
   FormControl,
   FormLabel,
   Switch,
@@ -51,7 +48,6 @@ export interface TopBarProps {
 }
 
 export function CoursesTopBar({ onFilter }: TopBarProps): JSX.Element {
-  const { isOpen, onToggle } = useDisclosure();
   const { term } = useParams();
   const location = useLocation();
   const [searchParams] = useSearchParams();
@@ -85,13 +81,7 @@ export function CoursesTopBar({ onFilter }: TopBarProps): JSX.Element {
             </BreadcrumbItem>
           )}
         </Breadcrumb>
-        <Box>
-          <Button onClick={onToggle} size="xs">
-            Filters
-          </Button>
-        </Box>
       </Flex>
-      <Collapse in={isOpen} animateOpacity>
         <Box p="3" shadow="md" borderTopWidth="2px" borderTopStyle="solid">
           <FormControl>
             <Flex justifyContent="space-between" w="100%">
@@ -102,7 +92,6 @@ export function CoursesTopBar({ onFilter }: TopBarProps): JSX.Element {
             </Flex>
           </FormControl>
         </Box>
-      </Collapse>
     </Box>
   );
 }

--- a/src/common/layouts/sidebar/variants/Courses.tsx
+++ b/src/common/layouts/sidebar/variants/Courses.tsx
@@ -82,16 +82,16 @@ export function CoursesTopBar({ onFilter }: TopBarProps): JSX.Element {
           )}
         </Breadcrumb>
       </Flex>
-        <Box p="3" shadow="md" borderTopWidth="2px" borderTopStyle="solid">
-          <FormControl>
-            <Flex justifyContent="space-between" w="100%">
-              <FormLabel htmlFor="email-alerts" mb="0" fontSize="sm">
-                Only Show Courses in Session
-              </FormLabel>
-              <Switch id="email-alerts" onChange={(e) => onFilter && onFilter(e.currentTarget.checked)} />
-            </Flex>
-          </FormControl>
-        </Box>
+      <Box p="3" shadow="md" borderTopWidth="2px" borderTopStyle="solid">
+        <FormControl>
+          <Flex justifyContent="space-between" w="100%">
+            <FormLabel htmlFor="email-alerts" mb="0" fontSize="sm">
+              Only Show Courses in Session
+            </FormLabel>
+            <Switch id="email-alerts" onChange={(e) => onFilter && onFilter(e.currentTarget.checked)} />
+          </Flex>
+        </FormControl>
+      </Box>
     </Box>
   );
 }

--- a/src/common/layouts/sidebar/variants/Courses.tsx
+++ b/src/common/layouts/sidebar/variants/Courses.tsx
@@ -45,6 +45,7 @@ export interface TopBarProps {
   /**
    * Back button click handler
    */
+  filter: boolean;
   onFilter?: (filter: boolean) => void;
 }
 
@@ -53,7 +54,6 @@ export function CoursesTopBar({ onFilter }: TopBarProps): JSX.Element {
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const mode = useDarkMode();
-  const [filter] = useSessionStorage<boolean>('filter_courses', true);
 
   const subject = location.pathname.split('/')[3];
   const route = location.pathname.split('/')[1];
@@ -93,7 +93,7 @@ export function CoursesTopBar({ onFilter }: TopBarProps): JSX.Element {
             <Switch
               id="email-alerts"
               onChange={(e) => onFilter && onFilter(e.currentTarget.checked)}
-              isChecked={filter}
+              
             />
           </Flex>
         </FormControl>
@@ -131,7 +131,7 @@ export function Courses({ term }: Props): JSX.Element | null {
 
   return (
     <>
-      <CoursesTopBar onFilter={handleFilter} />
+      <CoursesTopBar onFilter={handleFilter} filter/>
       {!loading && sortedSubjects && courses ? (
         <Box h="100%" overflowY="auto">
           <Routes>


### PR DESCRIPTION
# Description

The filters dropdown is now permanently open, displaying the one filter currently in place. The 'Filters' button which opened the dropdown is now completely deleted, since it is unnecessary. 

Closes #350 

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/25752638/158492433-baecc00a-f0ab-43c1-a053-7f44ee6f71b2.png)

### After
![image](https://user-images.githubusercontent.com/25752638/158492399-d6d018c3-83bd-418a-bcc2-d0841336441d.png)

## Checklist

- [X] The code follows all style guidelines.
- [ ] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [X] I have self-reviewed my changes and have done QA.

## General Comments

I am not sure how to add the state to session storage, and I am also unsure of the style guidelines or how code is tested+documented with CourseUp.
