### PR TITLE
Wardo/responsive sidebars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "restful-react": "^15.9.3",
         "rrule": "^2.6.4",
         "sass": "^1.49.7",
+        "swiper": "^8.0.7",
         "web-vitals": "^2.1.2"
       },
       "devDependencies": {
@@ -10728,6 +10729,14 @@
       "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/dom7": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+      "integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
+      "dependencies": {
+        "ssr-window": "^4.0.0"
       }
     },
     "node_modules/domelementtype": {
@@ -22404,6 +22413,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -22963,6 +22977,29 @@
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.0.7.tgz",
+      "integrity": "sha512-GHjDfxSZdupfU7LrSVOpaNaT7R1D2zxopPGBFz1UOXOtsYvVJLg0k6NvkTAD7qn0ASl5pTti82qoYwvYvIkg4g==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "hasInstallScript": true,
+      "dependencies": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -33161,6 +33198,14 @@
       "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
       "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q=="
     },
+    "dom7": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+      "integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
+      "requires": {
+        "ssr-window": "^4.0.0"
+      }
+    },
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
@@ -41654,6 +41699,11 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -42077,6 +42127,15 @@
             "decamelize": "^1.2.0"
           }
         }
+      }
+    },
+    "swiper": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.0.7.tgz",
+      "integrity": "sha512-GHjDfxSZdupfU7LrSVOpaNaT7R1D2zxopPGBFz1UOXOtsYvVJLg0k6NvkTAD7qn0ASl5pTti82qoYwvYvIkg4g==",
+      "requires": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
       }
     },
     "symbol-tree": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "restful-react": "^15.9.3",
         "rrule": "^2.6.4",
         "sass": "^1.49.7",
-        "swiper": "^8.0.7",
+        "swiper": "^8.1.0",
         "web-vitals": "^2.1.2"
       },
       "devDependencies": {
@@ -22980,9 +22980,9 @@
       }
     },
     "node_modules/swiper": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.0.7.tgz",
-      "integrity": "sha512-GHjDfxSZdupfU7LrSVOpaNaT7R1D2zxopPGBFz1UOXOtsYvVJLg0k6NvkTAD7qn0ASl5pTti82qoYwvYvIkg4g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.1.0.tgz",
+      "integrity": "sha512-Py2vuk7Nb3xlZMB2e201DQkjslTb6Uaju6wvr4BB7VjWrouSZegA0QjbxDVheJOsbKMUV092iDL3kymPBbuVzw==",
       "funding": [
         {
           "type": "patreon",
@@ -42130,9 +42130,9 @@
       }
     },
     "swiper": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.0.7.tgz",
-      "integrity": "sha512-GHjDfxSZdupfU7LrSVOpaNaT7R1D2zxopPGBFz1UOXOtsYvVJLg0k6NvkTAD7qn0ASl5pTti82qoYwvYvIkg4g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.1.0.tgz",
+      "integrity": "sha512-Py2vuk7Nb3xlZMB2e201DQkjslTb6Uaju6wvr4BB7VjWrouSZegA0QjbxDVheJOsbKMUV092iDL3kymPBbuVzw==",
       "requires": {
         "dom7": "^4.0.4",
         "ssr-window": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "restful-react": "^15.9.3",
     "rrule": "^2.6.4",
     "sass": "^1.49.7",
-    "swiper": "^8.0.7",
+    "swiper": "^8.1.0",
     "web-vitals": "^2.1.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "restful-react": "^15.9.3",
     "rrule": "^2.6.4",
     "sass": "^1.49.7",
+    "swiper": "^8.0.7",
     "web-vitals": "^2.1.2"
   },
   "scripts": {

--- a/src/common/layouts/Page.tsx
+++ b/src/common/layouts/Page.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren, useEffect, useState } from 'react';
 import { Flex, useMediaQuery } from '@chakra-ui/react';
 import { Helmet } from 'react-helmet';
 import { useLocation, useMatch, useNavigate, useParams } from 'react-router';
+// import { Swiper, SwiperSlide } from 'swiper/react';
 
 import { useSessionStorage } from 'lib/hooks/storage/useSessionStorage';
 import { getCurrentTerm } from 'lib/utils/terms';
@@ -11,6 +12,8 @@ import { Header } from 'common/header';
 import { Sidebar } from 'common/layouts/sidebar/containers/Sidebar';
 import { SearchResults } from 'common/layouts/sidebar/variants/SearchResults';
 import { Mobile } from 'common/mobile';
+
+import 'swiper/css';
 
 type Props = {
   title?: string;
@@ -44,31 +47,102 @@ export function Page({ title, leftSidebar, rightSidebar, mobileSupport, children
 
   return (
     <>
-      {!mobileSupport && <Mobile />}
       <Flex h="100vh" direction="column" overflowX="hidden" overflowY="hidden">
+        {!mobileSupport && <Mobile />}
+
         <Helmet>
           <title>{title}</title>
         </Helmet>
         <Header onSearchChange={handleSearchChange} />
-        <Flex overflowY="auto" h="100%">
-          {!isMobile && query.length > 0 ? (
+
+        {/* No mobile support */}
+        {!isMobile && query.length > 0 ? (
+          <Sidebar>
+            <SearchResults />
+          </Sidebar>
+        ) : (
+          leftSidebar && !isMobile && <Sidebar>{leftSidebar}</Sidebar>
+        )}
+        <Flex overflowY="auto" zIndex={56} w="100%" justifyContent="center" overflowX="hidden" boxShadow="md">
+          {isMobile && query.length > 0 ? (
             <Sidebar>
               <SearchResults />
             </Sidebar>
           ) : (
-            leftSidebar && !isMobile && <Sidebar>{leftSidebar}</Sidebar>
+            children
           )}
-          <Flex overflowY="auto" zIndex={56} w="100%" justifyContent="center" overflowX="hidden" boxShadow="md">
-            {isMobile && query.length > 0 ? (
-              <Sidebar>
-                <SearchResults />
-              </Sidebar>
-            ) : (
-              children
-            )}
-          </Flex>
-          {rightSidebar && !isMobile && <Sidebar>{rightSidebar}</Sidebar>}
         </Flex>
+        {rightSidebar && !isMobile && <Sidebar>{rightSidebar}</Sidebar>}
+
+        {/* Vanilla CSS mobile support */}
+        {/* <Flex>
+          {isMobile ? (
+            <Flex scrollSnapType="x mandatory" overflowX="scroll">
+              <Box scrollSnapAlign="start" minW="100%" overflowY="scroll">
+                {query.length > 0 ? (
+                  <Sidebar>
+                    <SearchResults />
+                  </Sidebar>
+                ) : (
+                  leftSidebar && <Sidebar>{leftSidebar}</Sidebar>
+                )}
+              </Box>
+              <Flex
+                scrollSnapAlign="start"
+                overflowY="auto"
+                zIndex={56}
+                minW="100%"
+                minH="100%"
+                justifyContent="center"
+                boxShadow="md"
+              >
+                {children}
+              </Flex>
+              <Box minW="100%" scrollSnapAlign="start" overflowY="scroll">
+                {rightSidebar && <Sidebar>{rightSidebar}</Sidebar>}
+              </Box>
+            </Flex>
+          ) : (
+            <>
+              {query.length > 0 ? (
+                <Sidebar>
+                  <SearchResults />
+                </Sidebar>
+              ) : (
+                leftSidebar && <Sidebar>{leftSidebar}</Sidebar>
+              )}
+              <Flex overflowY="auto" zIndex={56} w="100%" justifyContent="center" boxShadow="md">
+                {children}
+              </Flex>
+              {rightSidebar && !isMobile && <Sidebar>{rightSidebar}</Sidebar>}
+            </>
+          )}
+        </Flex> */}
+
+        {/* Swiper mobile support */}
+        {/* <Flex overflowY="auto" h="100%">
+          {isMobile ? (
+            <Swiper initialSlide={1}>
+              {leftSidebar ? <SwiperSlide>{leftSidebar}</SwiperSlide> : null}
+              <SwiperSlide>{children}</SwiperSlide>
+              {rightSidebar ? <SwiperSlide>{rightSidebar}</SwiperSlide> : null}
+            </Swiper>
+          ) : (
+            <>
+              {query.length > 0 ? (
+                <Sidebar>
+                  <SearchResults />
+                </Sidebar>
+              ) : (
+                leftSidebar && <Sidebar>{leftSidebar}</Sidebar>
+              )}
+              <Flex overflowY="auto" zIndex={56} w="100%" justifyContent="center" boxShadow="md">
+                {children}
+              </Flex>
+              {rightSidebar && !isMobile && <Sidebar>{rightSidebar}</Sidebar>}
+            </>
+          )}
+        </Flex> */}
       </Flex>
     </>
   );

--- a/src/common/layouts/Page.tsx
+++ b/src/common/layouts/Page.tsx
@@ -3,7 +3,7 @@ import { PropsWithChildren, useEffect, useState } from 'react';
 import { Flex, useMediaQuery } from '@chakra-ui/react';
 import { Helmet } from 'react-helmet';
 import { useLocation, useMatch, useNavigate, useParams } from 'react-router';
-// import { Swiper, SwiperSlide } from 'swiper/react';
+import { Swiper, SwiperSlide } from 'swiper/react';
 
 import { useSessionStorage } from 'lib/hooks/storage/useSessionStorage';
 import { getCurrentTerm } from 'lib/utils/terms';
@@ -56,7 +56,7 @@ export function Page({ title, leftSidebar, rightSidebar, mobileSupport, children
         <Header onSearchChange={handleSearchChange} />
 
         {/* No mobile support */}
-        {!isMobile && query.length > 0 ? (
+        {/* {!isMobile && query.length > 0 ? (
           <Sidebar>
             <SearchResults />
           </Sidebar>
@@ -72,7 +72,7 @@ export function Page({ title, leftSidebar, rightSidebar, mobileSupport, children
             children
           )}
         </Flex>
-        {rightSidebar && !isMobile && <Sidebar>{rightSidebar}</Sidebar>}
+        {rightSidebar && !isMobile && <Sidebar>{rightSidebar}</Sidebar>} */}
 
         {/* Vanilla CSS mobile support */}
         {/* <Flex>
@@ -120,7 +120,7 @@ export function Page({ title, leftSidebar, rightSidebar, mobileSupport, children
         </Flex> */}
 
         {/* Swiper mobile support */}
-        {/* <Flex overflowY="auto" h="100%">
+        <Flex overflowY="auto" h="100%">
           {isMobile ? (
             <Swiper initialSlide={1}>
               {leftSidebar ? <SwiperSlide>{leftSidebar}</SwiperSlide> : null}
@@ -142,7 +142,7 @@ export function Page({ title, leftSidebar, rightSidebar, mobileSupport, children
               {rightSidebar && !isMobile && <Sidebar>{rightSidebar}</Sidebar>}
             </>
           )}
-        </Flex> */}
+        </Flex>
       </Flex>
     </>
   );

--- a/src/common/layouts/Page.tsx
+++ b/src/common/layouts/Page.tsx
@@ -1,6 +1,22 @@
 import { PropsWithChildren, useEffect, useState } from 'react';
+// Import Swiper styles
+import 'swiper/css';
+import 'swiper/css/pagination';
 
-import { Flex, useMediaQuery } from '@chakra-ui/react';
+import {
+  Flex,
+  //HStack,
+  useMediaQuery,
+  //VStack,
+  // Drawer,
+  // DrawerBody,
+  // DrawerFooter,
+  // DrawerHeader,
+  // DrawerOverlay,
+  // DrawerContent,
+  // DrawerCloseButton,
+  // useDisclosure,
+} from '@chakra-ui/react';
 import { Helmet } from 'react-helmet';
 import { useLocation, useMatch, useNavigate, useParams } from 'react-router';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -12,8 +28,6 @@ import { Header } from 'common/header';
 import { Sidebar } from 'common/layouts/sidebar/containers/Sidebar';
 import { SearchResults } from 'common/layouts/sidebar/variants/SearchResults';
 import { Mobile } from 'common/mobile';
-
-import 'swiper/css';
 
 type Props = {
   title?: string;
@@ -29,8 +43,15 @@ export function Page({ title, leftSidebar, rightSidebar, mobileSupport, children
   const location = useLocation();
   const [isMobile] = useMediaQuery('(max-width: 1020px)');
   const { term, slug } = useParams();
+  //const { isOpen, onOpen, onClose } = useDisclosure();
 
   const route = location.pathname.split('/')[1];
+
+  const pagination = {
+    el: 'swiper-pagination',
+    clickable: true,
+    renderBullet: () => <span>' + (index + 1) + '</span>,
+  };
 
   const handleSearchChange = (q: string) => {
     setQuery(q);
@@ -47,13 +68,48 @@ export function Page({ title, leftSidebar, rightSidebar, mobileSupport, children
 
   return (
     <>
+      {!mobileSupport && <Mobile />}
       <Flex h="100vh" direction="column" overflowX="hidden" overflowY="hidden">
-        {!mobileSupport && <Mobile />}
-
         <Helmet>
           <title>{title}</title>
         </Helmet>
         <Header onSearchChange={handleSearchChange} />
+
+        {/* <Flex overflowY="auto" h="100%">
+          {!isMobile ? (
+            <>
+              {query.length > 0 ? (
+                <Sidebar side="left">
+                  <SearchResults />
+                </Sidebar>
+              ) : (
+                leftSidebar && <Sidebar side="left">{leftSidebar}</Sidebar>
+              )}
+              <Flex overflowY="auto" zIndex={56} w="100%" justifyContent="center" boxShadow="md">
+                {children}
+              </Flex>
+              {rightSidebar && <Sidebar side="right">{rightSidebar}</Sidebar>}
+            </>
+          ) : (
+            <>
+              <VStack w="100%" spacing={5} pt={5} minH="100vh">
+                <HStack px={5} w="100%" justify="space-between">
+                  {query.length > 0 ? (
+                    <Sidebar side="left" title="Search Results">
+                      <SearchResults />
+                    </Sidebar>
+                  ) : (
+                    leftSidebar && <Sidebar side="left">{leftSidebar}</Sidebar>
+                  )}
+                  {rightSidebar && <Sidebar side="right">{rightSidebar}</Sidebar>}
+                </HStack>
+                <Flex overflowY="auto" zIndex={56} w="100%" justifyContent="center" boxShadow="md">
+                  {children}
+                </Flex>
+              </VStack>
+            </>
+          )}
+        </Flex> */}
 
         {/* No mobile support */}
         {/* {!isMobile && query.length > 0 ? (
@@ -120,12 +176,18 @@ export function Page({ title, leftSidebar, rightSidebar, mobileSupport, children
         </Flex> */}
 
         {/* Swiper mobile support */}
-        <Flex overflowY="auto" h="100%">
+        <Flex overflowY="auto" h="100%" w="100%">
           {isMobile ? (
-            <Swiper initialSlide={1}>
-              {leftSidebar ? <SwiperSlide>{leftSidebar}</SwiperSlide> : null}
-              <SwiperSlide>{children}</SwiperSlide>
-              {rightSidebar ? <SwiperSlide>{rightSidebar}</SwiperSlide> : null}
+            <Swiper pagination={pagination} initialSlide={1}>
+              {query.length > 0 ? (
+                <SwiperSlide>
+                  <SearchResults />
+                </SwiperSlide>
+              ) : (
+                leftSidebar && <SwiperSlide>{leftSidebar}</SwiperSlide>
+              )}
+              <SwiperSlide style={{ width: '100%' }}>{children}</SwiperSlide>
+              {rightSidebar && <SwiperSlide>{rightSidebar}</SwiperSlide>}
             </Swiper>
           ) : (
             <>

--- a/src/common/layouts/sidebar/containers/Sidebar.tsx
+++ b/src/common/layouts/sidebar/containers/Sidebar.tsx
@@ -1,29 +1,64 @@
-import { Flex, useMediaQuery } from '@chakra-ui/react';
+import {
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerOverlay,
+  Flex,
+  useDisclosure,
+  useMediaQuery,
+} from '@chakra-ui/react';
 
 import { useDarkMode } from 'lib/hooks/useDarkMode';
 
-export function Sidebar({ children }: { children: JSX.Element }): JSX.Element | null {
+export function Sidebar({
+  children,
+  side,
+  title,
+}: {
+  children: JSX.Element;
+  side?: 'left' | 'right';
+  title?: string;
+}): JSX.Element | null {
   const mode = useDarkMode();
   const [isMobile] = useMediaQuery('(max-width: 1020px)');
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  //console.log(title);
 
   return (
-    <Flex
-      bgColor={mode('light.background', 'dark.background')}
-      minW={isMobile ? '100%' : '20%'}
-      maxW={isMobile ? '100%' : '20%'}
-      flexDirection="column"
-      h="100%"
-    >
-      <Flex
-        justifyContent="flex-start"
-        height="100%"
-        width="100%"
-        overflowX="hidden"
-        overflowY="auto"
-        direction="column"
-      >
-        {children}
-      </Flex>
-    </Flex>
+    <>
+      {!isMobile ? (
+        <Flex
+          bgColor={mode('light.background', 'dark.background')}
+          minW={isMobile ? '100%' : '20%'}
+          maxW={isMobile ? '100%' : '20%'}
+          flexDirection="column"
+          h="100%"
+        >
+          <Flex
+            justifyContent="flex-start"
+            height="100%"
+            width="100%"
+            overflowX="hidden"
+            overflowY="auto"
+            direction="column"
+          >
+            {children}
+          </Flex>
+        </Flex>
+      ) : (
+        <>
+          <Button onClick={onOpen}>{title || side === 'left' ? '<' : '>'}</Button>
+          <Drawer size="lg" isOpen={isOpen} placement={side} onClose={onClose}>
+            <DrawerOverlay />
+            <DrawerContent>
+              <DrawerCloseButton />
+              <DrawerBody>{children}</DrawerBody>
+            </DrawerContent>
+          </Drawer>
+        </>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
# Description

Makes the `Page` component responsive on mobile screen by making it so that a user can swipe between the toolbars and the main components. It's a work in progress.
The current version is using the Swiper library, but there's also commented code on an option using CSS.

![ezgif-2-a6bca03bce](https://user-images.githubusercontent.com/50898635/162654521-0be8cf8d-e7b6-41f7-ad38-b34ae0a885bf.gif)

Closes #318 

## Checklist

- [ ] The code follows all style guidelines.
- [ ] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [ ] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
