### PR TITLE
Switch frontend to use banner v9

### DIFF
--- a/src/pages/calendar/containers/Section.tsx
+++ b/src/pages/calendar/containers/Section.tsx
@@ -32,7 +32,11 @@ export interface SectionsContainerProps {
 }
 
 export function SectionsContainer({ term, subject, code }: SectionsContainerProps): JSX.Element {
-  const { data: sections, loading, error: sectionsError } = useSections({ term, queryParams: { subject, code } });
+  const {
+    data: sections,
+    loading,
+    error: sectionsError,
+  } = useSections({ term, queryParams: { subject, code, v9: true } });
   const { data: seats, error: seatsError } = useSeats({ term, queryParams: { subject, code } });
   const mode = useDarkMode();
 

--- a/src/pages/registration/containers/CourseContainer.tsx
+++ b/src/pages/registration/containers/CourseContainer.tsx
@@ -31,7 +31,7 @@ export function CourseContainer({ course }: Props) {
 
   const { data: sections, loading } = useSections({
     term: termType,
-    queryParams: { subject: course.subject, code: course.code },
+    queryParams: { subject: course.subject, code: course.code, v9: true },
   });
   const { data: seats } = useSeats({
     term: termType,


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change(s) and which issue is being fixed. Please provide as much detail as possible. -->

Switches the frontend to make calls to banner v9 instead of v8. 
Don't need to merge this yet, but if uvic goes through and deprecates v8 like they said we need this.

## Checklist

- [ ] The code follows all style guidelines.
- [ ] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [ ] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
