### PR TITLE
fix: use kuali data to generate subjects

### DIFF
--- a/functions/src/subjects/Subject.service.ts
+++ b/functions/src/subjects/Subject.service.ts
@@ -1,11 +1,30 @@
-import { UVicCourseScraper } from '@vikelabs/uvic-course-scraper/dist';
+import {
+  KualiSubject,
+  UVicCourseScraper,
+} from '@vikelabs/uvic-course-scraper/dist';
 import { Term } from '../constants';
 import { Subject } from './Subject.model';
 
 export class SubjectsService {
   public static async getSubjects(term: Term): Promise<Subject[]> {
-    const subjects = await UVicCourseScraper.getSubjects(term);
-    return subjects.map(({ subject, title }) => ({
+    const subjects: KualiSubject[] = (
+      await UVicCourseScraper.getCourses(term)
+    ).response.map((course) => {
+      return {
+        subject: course.subjectCode.name,
+        title: course.subjectCode.description,
+      };
+    });
+
+    // remove duplicates based on two keys
+
+    const m = new Map<string, KualiSubject>();
+    subjects.forEach((subject) => {
+      m.set(`${subject.subject}-${subject.title}`, subject);
+    });
+
+    // map to array
+    return Array.from(m.values()).map(({ subject, title }) => ({
       subject,
       // removes the subject within the title
       title: title.replace(`(${subject})`, '').trim(),


### PR DESCRIPTION
# Description

As part of ongoing Banner v8 deprecation, this PR patches the subjects endpoint to use Kuali data rather than Banner V8.
It generates a list of subjects by grabbing the courses list and mapping it into subjects. Duplicates are then removed from this.

## Checklist

- [ ] The code follows all style guidelines.
- [ ] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [ ] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
