### PR TITLE
fix: Timetable share modal size

### DIFF
--- a/src/pages/scheduler/components/share/ShareTimetableModal.tsx
+++ b/src/pages/scheduler/components/share/ShareTimetableModal.tsx
@@ -28,7 +28,7 @@ export default function ShareTimetableModal({
 
   return (
     <>
-      <Modal size={isSmallScreen ? '2xl' : 'full'} onClose={onClose} isOpen={isOpen} isCentered>
+      <Modal size={isSmallScreen ? 'full' : '2xl'} onClose={onClose} isOpen={isOpen} isCentered>
         <ModalOverlay />
         <ModalContent alignItems="center">
           <ModalHeader>Share your {getReadableTerm(term || '')} timetable</ModalHeader>


### PR DESCRIPTION
# Description
Fixes the timetable share modal size based on screen size by swapping the values.
<!-- Please include a summary of the change(s) and which issue is being fixed. Please provide as much detail as possible. -->

<!-- Replace `XX` with the concerning issue number. -->
Closes #XX

## Screenshots
<!-- Delete this section if changes do not require screenshots -->

<!-- Include any relevant screenshots or gifs to all frontend changes when applicable. -->

### Before
<!-- Add before screenshots when applicable. -->
![image](https://user-images.githubusercontent.com/1757744/174345795-6bb6f62c-29dc-48d8-bacd-4605afa72815.png)

![image](https://user-images.githubusercontent.com/1757744/174345750-7cb20e4e-f4b8-4a9a-8bed-ebf4b2b0bef4.png)

### After
![image](https://user-images.githubusercontent.com/1757744/174345833-863ab272-9be5-4e7a-baf1-429ca1b8e7f8.png)

![image](https://user-images.githubusercontent.com/1757744/174345679-a3741a6f-baff-4da4-aacc-c7a703f313e7.png)


## Checklist

- [ ] The code follows all style guidelines.
- [ ] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [ ] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
