### PR TITLE
Feat: Responsive timetable

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,6 +23,7 @@ const config = {
   modulePaths: ['<rootDir>/src/'],
   moduleNameMapper: {
     '^.+\\.(css|scss)$': '<rootDir>/src/lib/utils/jest/__mocks__/styleMock.js',
+    '^swiper.*$': '<rootDir>/src/lib/utils/jest/__mocks__/moduleMock.js',
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "restful-react": "^15.9.3",
         "rrule": "^2.6.4",
         "sass": "^1.49.7",
+        "swiper": "^8.2.4",
         "web-vitals": "^2.1.2"
       },
       "devDependencies": {
@@ -10745,6 +10746,14 @@
       "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/dom7": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+      "integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
+      "dependencies": {
+        "ssr-window": "^4.0.0"
       }
     },
     "node_modules/domelementtype": {
@@ -22433,6 +22442,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -22992,6 +23006,29 @@
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.2.4.tgz",
+      "integrity": "sha512-TPq64KiZUt8lZY5ZEg75RjToT+RwfLomfKIpcFLy6+UCUp2kL7hHWslLxjFtcFeiwfG67RHFYbJnq6tsothcJQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "hasInstallScript": true,
+      "dependencies": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -33219,6 +33256,14 @@
       "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
       "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q=="
     },
+    "dom7": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+      "integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
+      "requires": {
+        "ssr-window": "^4.0.0"
+      }
+    },
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
@@ -41721,6 +41766,11 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -42144,6 +42194,15 @@
             "decamelize": "^1.2.0"
           }
         }
+      }
+    },
+    "swiper": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.2.4.tgz",
+      "integrity": "sha512-TPq64KiZUt8lZY5ZEg75RjToT+RwfLomfKIpcFLy6+UCUp2kL7hHWslLxjFtcFeiwfG67RHFYbJnq6tsothcJQ==",
+      "requires": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
       }
     },
     "symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "restful-react": "^15.9.3",
     "rrule": "^2.6.4",
     "sass": "^1.49.7",
+    "swiper": "^8.2.4",
     "web-vitals": "^2.1.2"
   },
   "scripts": {

--- a/src/common/layouts/Page.tsx
+++ b/src/common/layouts/Page.tsx
@@ -26,49 +26,6 @@ type Props = {
   mobileSupport?: boolean;
 };
 
-const MobilePage = ({
-  query,
-  leftSidebar,
-  rightSidebar,
-  children,
-}: {
-  query: string;
-  leftSidebar?: JSX.Element;
-  rightSidebar?: JSX.Element;
-  children?: React.ReactNode;
-}): JSX.Element => {
-  const [swiper, setSwiper] = useState(null);
-
-  useEffect(() => {
-    if (query.length > 0 && swiper) {
-      //@ts-ignore
-      swiper.slideTo(0);
-    }
-  }, [query, swiper]);
-
-  return (
-    <Swiper
-      modules={[Pagination]}
-      pagination={{
-        clickable: true,
-      }}
-      initialSlide={1}
-      //@ts-ignore
-      onSwiper={(swiper) => setSwiper(swiper)}
-    >
-      {query.length > 0 ? (
-        <SwiperSlide>
-          <SearchResults />
-        </SwiperSlide>
-      ) : (
-        leftSidebar && <SwiperSlide>{leftSidebar}</SwiperSlide>
-      )}
-      <SwiperSlide style={{ overflowY: 'scroll', width: '100vw' }}>{children}</SwiperSlide>
-      {rightSidebar && <SwiperSlide>{rightSidebar}</SwiperSlide>}
-    </Swiper>
-  );
-};
-
 export function Page({ title, leftSidebar, rightSidebar, mobileSupport, children }: PropsWithChildren<Props>) {
   const [query, setQuery] = useState('');
   const [savedTerm, setSavedTerm] = useSessionStorage('user:term', getCurrentTerm());
@@ -82,6 +39,14 @@ export function Page({ title, leftSidebar, rightSidebar, mobileSupport, children
   const handleSearchChange = (q: string) => {
     setQuery(q);
   };
+
+  const [swiper, setSwiper] = useState<any>(null);
+
+  useEffect(() => {
+    if (query.length > 0 && swiper) {
+      swiper.slideTo(0);
+    }
+  }, [query, swiper]);
 
   const contest = useMatch('/contest');
   useEffect(() => {
@@ -102,7 +67,26 @@ export function Page({ title, leftSidebar, rightSidebar, mobileSupport, children
         <Header onSearchChange={handleSearchChange} />
         <Flex overflowY="auto" h="100%">
           {smallScreen ? (
-            <MobilePage query={query} leftSidebar={leftSidebar} rightSidebar={rightSidebar} children={children} />
+            <Swiper
+              modules={[Pagination]}
+              pagination={{
+                clickable: true,
+              }}
+              initialSlide={1}
+              onSwiper={(swiper) => {
+                setSwiper(swiper);
+              }}
+            >
+              {query.length > 0 ? (
+                <SwiperSlide>
+                  <SearchResults />
+                </SwiperSlide>
+              ) : (
+                leftSidebar && <SwiperSlide>{leftSidebar}</SwiperSlide>
+              )}
+              <SwiperSlide style={{ overflowY: 'scroll', width: '100vw' }}>{children}</SwiperSlide>
+              {rightSidebar && <SwiperSlide>{rightSidebar}</SwiperSlide>}
+            </Swiper>
           ) : (
             <>
               {query.length > 0 ? (

--- a/src/common/layouts/Page.tsx
+++ b/src/common/layouts/Page.tsx
@@ -7,7 +7,6 @@ import { Pagination } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import 'swiper/css/pagination';
-import '../../index.css';
 
 import { useSessionStorage } from 'lib/hooks/storage/useSessionStorage';
 import { useSmallScreen } from 'lib/hooks/useSmallScreen';

--- a/src/common/layouts/Page.tsx
+++ b/src/common/layouts/Page.tsx
@@ -3,6 +3,11 @@ import { PropsWithChildren, useEffect, useState } from 'react';
 import { Flex } from '@chakra-ui/react';
 import { Helmet } from 'react-helmet';
 import { useLocation, useMatch, useNavigate, useParams } from 'react-router';
+import { Pagination } from 'swiper';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
+import 'swiper/css/pagination';
+import '../../index.css';
 
 import { useSessionStorage } from 'lib/hooks/storage/useSessionStorage';
 import { useSmallScreen } from 'lib/hooks/useSmallScreen';
@@ -19,6 +24,49 @@ type Props = {
   leftSidebar?: JSX.Element;
   rightSidebar?: JSX.Element;
   mobileSupport?: boolean;
+};
+
+const MobilePage = ({
+  query,
+  leftSidebar,
+  rightSidebar,
+  children,
+}: {
+  query: string;
+  leftSidebar?: JSX.Element;
+  rightSidebar?: JSX.Element;
+  children?: React.ReactNode;
+}): JSX.Element => {
+  const [swiper, setSwiper] = useState(null);
+
+  useEffect(() => {
+    if (query.length > 0 && swiper) {
+      //@ts-ignore
+      swiper.slideTo(0);
+    }
+  }, [query, swiper]);
+
+  return (
+    <Swiper
+      modules={[Pagination]}
+      pagination={{
+        clickable: true,
+      }}
+      initialSlide={1}
+      //@ts-ignore
+      onSwiper={(swiper) => setSwiper(swiper)}
+    >
+      {query.length > 0 ? (
+        <SwiperSlide>
+          <SearchResults />
+        </SwiperSlide>
+      ) : (
+        leftSidebar && <SwiperSlide>{leftSidebar}</SwiperSlide>
+      )}
+      <SwiperSlide style={{ overflowY: 'scroll', width: '100vw' }}>{children}</SwiperSlide>
+      {rightSidebar && <SwiperSlide>{rightSidebar}</SwiperSlide>}
+    </Swiper>
+  );
 };
 
 export function Page({ title, leftSidebar, rightSidebar, mobileSupport, children }: PropsWithChildren<Props>) {
@@ -47,29 +95,29 @@ export function Page({ title, leftSidebar, rightSidebar, mobileSupport, children
   return (
     <>
       {!mobileSupport && <Mobile />}
-      <Flex h={isMobile ? window.innerHeight : '100vh'} direction="column" overflowX="hidden" overflowY="hidden">
+      <Flex h={smallScreen ? window.innerHeight : '100vh'} direction="column" overflowX="hidden" overflowY="hidden">
         <Helmet>
           <title>{title}</title>
         </Helmet>
         <Header onSearchChange={handleSearchChange} />
         <Flex overflowY="auto" h="100%">
-          {!smallScreen && query.length > 0 ? (
-            <Sidebar>
-              <SearchResults />
-            </Sidebar>
+          {smallScreen ? (
+            <MobilePage query={query} leftSidebar={leftSidebar} rightSidebar={rightSidebar} children={children} />
           ) : (
-            leftSidebar && !smallScreen && <Sidebar>{leftSidebar}</Sidebar>
+            <>
+              {query.length > 0 ? (
+                <Sidebar>
+                  <SearchResults />
+                </Sidebar>
+              ) : (
+                leftSidebar && <Sidebar>{leftSidebar}</Sidebar>
+              )}
+              <Flex overflowY="auto" zIndex={56} w="100%" justifyContent="center" boxShadow="md">
+                {children}
+              </Flex>
+              {rightSidebar && !isMobile && <Sidebar>{rightSidebar}</Sidebar>}
+            </>
           )}
-          <Flex overflowY="auto" zIndex={56} w="100%" justifyContent="center" overflowX="hidden" boxShadow="md">
-            {smallScreen && query.length > 0 ? (
-              <Sidebar>
-                <SearchResults />
-              </Sidebar>
-            ) : (
-              children
-            )}
-          </Flex>
-          {rightSidebar && !smallScreen && <Sidebar>{rightSidebar}</Sidebar>}
         </Flex>
       </Flex>
     </>

--- a/src/common/layouts/styles/swiperPagination.tsx
+++ b/src/common/layouts/styles/swiperPagination.tsx
@@ -1,0 +1,16 @@
+import { CSSProperties } from 'react';
+
+export const SwiperPaginationTheme = (): CSSProperties => {
+  return {
+    '.swiper-pagination-bullet': {
+      borderRadius: 10,
+      width: '50px',
+      height: '10px',
+      opacity: 1,
+      backgroundColor: 'RGBA(0, 0, 0, 0.24)',
+    },
+    '.swiper-pagination-bullet-active': {
+      backgroundColor: 'RGBA(0, 0, 0, 0.64)',
+    },
+  } as CSSProperties;
+};

--- a/src/common/layouts/styles/swiperPagination.tsx
+++ b/src/common/layouts/styles/swiperPagination.tsx
@@ -1,16 +1,19 @@
 import { CSSProperties } from 'react';
 
-export const SwiperPaginationTheme = (): CSSProperties => {
+import { mode } from '@chakra-ui/theme-tools';
+
+export const SwiperPaginationTheme = (colorMode: 'light' | 'dark'): CSSProperties => {
+  const props = { colorMode };
   return {
     '.swiper-pagination-bullet': {
       borderRadius: 10,
       width: '50px',
       height: '10px',
       opacity: 1,
-      backgroundColor: 'RGBA(0, 0, 0, 0.24)',
+      backgroundColor: mode('RGBA(0, 0, 0, 0.24)', 'RGBA(255, 255, 255, 0.30)')(props),
     },
     '.swiper-pagination-bullet-active': {
-      backgroundColor: 'RGBA(0, 0, 0, 0.64)',
+      backgroundColor: mode('RGBA(0, 0, 0, 0.64)', 'RGBA(255, 255, 255, 0.75)')(props),
     },
   } as CSSProperties;
 };

--- a/src/lib/theme.tsx
+++ b/src/lib/theme.tsx
@@ -1,5 +1,7 @@
 import { extendTheme, ThemeConfig } from '@chakra-ui/react';
 
+import { SwiperPaginationTheme } from 'common/layouts/styles/swiperPagination';
+
 import { CalendarTheme } from 'pages/scheduler/styles/calendar';
 
 const config: ThemeConfig = {
@@ -22,6 +24,7 @@ export const customTheme = extendTheme({
         boxShadow: 'none !important',
       },
       ...CalendarTheme(props.colorMode),
+      ...SwiperPaginationTheme(),
     }),
   },
 });

--- a/src/lib/theme.tsx
+++ b/src/lib/theme.tsx
@@ -24,7 +24,7 @@ export const customTheme = extendTheme({
         boxShadow: 'none !important',
       },
       ...CalendarTheme(props.colorMode),
-      ...SwiperPaginationTheme(),
+      ...SwiperPaginationTheme(props.colorMode),
     }),
   },
 });

--- a/src/lib/utils/jest/__mocks__/moduleMock.js
+++ b/src/lib/utils/jest/__mocks__/moduleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/src/pages/scheduler/containers/SchedulerContainer.tsx
+++ b/src/pages/scheduler/containers/SchedulerContainer.tsx
@@ -4,6 +4,7 @@ import { Box, Flex } from '@chakra-ui/react';
 import { useParams } from 'react-router';
 
 import { useSavedCourses } from 'lib/hooks/useSavedCourses';
+import { useSmallScreen } from 'lib/hooks/useSmallScreen';
 import { getCurrentTerm } from 'lib/utils/terms';
 
 import { SchedulerCalendar } from '../components/SchedulerCalendar';
@@ -22,10 +23,11 @@ export function SchedulerContainer(): JSX.Element {
     () => denormalizeCourseEvents(coursesResult.status === 'loaded' ? coursesResult.data : []),
     [coursesResult]
   );
+  const smallScreen = useSmallScreen();
 
   return (
     <Flex flexGrow={1} height="100%" overflow="hidden" direction={'column'}>
-      <Box w="100%" height="100%" px="3" py="2">
+      <Box w="100%" height="100%" px={smallScreen ? '0' : '3'} py={smallScreen ? '1' : '2'}>
         <SchedulerCalendar term={term || getCurrentTerm()} courseCalendarEvents={calendarEvents} />
         <ScreenshotFooter />
       </Box>

--- a/src/pages/scheduler/containers/SchedulerContainer.tsx
+++ b/src/pages/scheduler/containers/SchedulerContainer.tsx
@@ -27,7 +27,7 @@ export function SchedulerContainer(): JSX.Element {
 
   return (
     <Flex flexGrow={1} height="100%" overflow="hidden" direction={'column'}>
-      <Box w="100%" height="100%" px={smallScreen ? '0' : '3'} py={smallScreen ? '1' : '2'}>
+      <Box w="100%" height="100%" px={smallScreen ? '1' : '3'} pt={'2'} pb={smallScreen ? '0' : '2'}>
         <SchedulerCalendar term={term || getCurrentTerm()} courseCalendarEvents={calendarEvents} />
         <ScreenshotFooter />
       </Box>

--- a/src/pages/scheduler/index.tsx
+++ b/src/pages/scheduler/index.tsx
@@ -16,6 +16,7 @@ export function Scheduler(): JSX.Element {
       title="Scheduler"
       leftSidebar={<Courses term={term as Term} />}
       rightSidebar={<SchedulerSidebar term={term} />}
+      mobileSupport
     >
       <SchedulerContainer />
     </Page>


### PR DESCRIPTION
# Description

This PR changes the Page component to be responsive on mobile using Swiper. A menu bar at the bottom shows your current page and you can swipe or click to switch between them.

Closes #318 

## Screenshots

### Before (no way of switching away from the scheduler screen)
<img width="250" alt="image" src="https://user-images.githubusercontent.com/50898635/175210006-a8311df4-a5d2-4241-a64f-c5dd1ca60b07.png">

### After
<img width="250" alt="image" src="https://user-images.githubusercontent.com/50898635/175337918-cb1f8336-ff6a-498b-884f-9bba18ce620e.png">

Here's a little GIF of it in action: https://imgur.com/a/wj0E4x6

## Checklist

- [x] The code follows all style guidelines.
- [X] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.

## General comments

When a user starts typing something in the menubar, it slides them back to the left most slide (left sidebar, as it includes search results).
This is done using a bit of a workaround using `useState`. The best would be to use the `useSwiper` hook they provide, but that needs to be in a _direct_ child component of `Swiper`, which is not possible for our use case since the menu bar is the one that triggers the slide, which won't be inside Swiper...