### PR TITLE
Changing style of import page

### DIFF
--- a/src/pages/import/components/ImportCalendar.tsx
+++ b/src/pages/import/components/ImportCalendar.tsx
@@ -6,6 +6,7 @@ import { Box } from '@chakra-ui/layout';
 
 import { Timetable } from 'lib/fetchers';
 import { SavedCourse } from 'lib/hooks/useSavedCourses';
+import { useSmallScreen } from 'lib/hooks/useSmallScreen';
 import { getCurrentTerm } from 'lib/utils/terms';
 
 import { SchedulerCalendar } from 'pages/scheduler/components/SchedulerCalendar';
@@ -14,6 +15,7 @@ import { denormalizeCourseEvents } from 'pages/scheduler/hooks/useTransformedCal
 
 export const ImportCalendar = ({ timetableCourses }: { timetableCourses: Timetable }): JSX.Element => {
   const { courses, term } = timetableCourses;
+  const smallScreen = useSmallScreen();
 
   const parsedCourses: SavedCourse[] = useMemo(
     () =>
@@ -43,7 +45,7 @@ export const ImportCalendar = ({ timetableCourses }: { timetableCourses: Timetab
   );
 
   return (
-    <Box w="100%" px="3" pb="14" h="100%">
+    <Box w="100%" px={smallScreen ? 1 : 3} pb="14" h="100%">
       <SchedulerCalendar term={term || getCurrentTerm()} courseCalendarEvents={calendarEvents} />
     </Box>
   );

--- a/src/pages/import/components/TimetableCourseTags.tsx
+++ b/src/pages/import/components/TimetableCourseTags.tsx
@@ -1,0 +1,37 @@
+import { Wrap, WrapItem } from '@chakra-ui/react';
+
+import { Term, TimetableCourse } from 'lib/fetchers';
+
+import { NotFound } from 'common/notFound/NotFound';
+
+import { ShareCourseCard } from 'pages/scheduler/components/share/SelectedCoursesCardList';
+
+export function TimetableCourseTags({ courses, term }: { courses: TimetableCourse[]; term: Term }) {
+  return (
+    <Wrap p={5} justify="center">
+      {courses.length > 0 ? (
+        courses.map((course) => {
+          if (course.lecture || course.lab || course.tutorial) {
+            return (
+              <WrapItem key={`${course.subject}${course.code}`}>
+                <ShareCourseCard
+                  lecture={course.lecture && course.lecture[0]}
+                  lab={course.lab && course.lab[0]}
+                  tutorial={course.tutorial && course.tutorial[0]}
+                  term={term}
+                  subject={course.subject}
+                  pid={course.pid}
+                  code={course.code}
+                  color={course.color}
+                />
+              </WrapItem>
+            );
+          }
+          return null;
+        })
+      ) : (
+        <NotFound term={term}> Unable to find saved courses for</NotFound>
+      )}
+    </Wrap>
+  );
+}

--- a/src/pages/import/index.tsx
+++ b/src/pages/import/index.tsx
@@ -68,7 +68,7 @@ export function ImportTimetable(): JSX.Element {
   return (
     <Page title="View Timetable" leftSidebar={left} rightSidebar={right} mobileSupport>
       {smallScreen ? (
-        <VStack pt={2} w="100%" h="100%" overflow="hidden" flexGrow={1} px="3">
+        <VStack pt={2} w="100%" h="100%" overflow="hidden" flexGrow={1} px={1}>
           <HStack justify="space-between" w="100%">
             <Heading>{!loading && data ? getReadableTerm(term) : 'Viewing Timetable'}</Heading>
             <ButtonGroup isAttached colorScheme="green">

--- a/src/pages/import/index.tsx
+++ b/src/pages/import/index.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Spinner, VStack, Heading, HStack, Flex, Box, ButtonGroup, Button, Center } from '@chakra-ui/react';
 import { useParams } from 'react-router';
 
-import { Timetable, useGetTimetable } from 'lib/fetchers';
+import { Term, Timetable, TimetableCourse, useGetTimetable } from 'lib/fetchers';
 import { useSmallScreen } from 'lib/hooks/useSmallScreen';
 import { getReadableTerm } from 'lib/utils/terms';
 
@@ -14,44 +14,51 @@ import { Sidebar } from 'common/layouts/sidebar/containers/Sidebar';
 import { ImportCalendar } from './components/ImportCalendar';
 import { TimetableActionButtons } from './components/TimetableActionButtons';
 import { TimetableCourseCard } from './components/TimetableCourseCard';
+import { TimetableCourseTags } from './components/TimetableCourseTags';
 
 export function ImportTimetable(): JSX.Element {
   const { slug } = useParams();
   const smallScreen = useSmallScreen();
 
   const { loading, data } = useGetTimetable({ slug: slug });
+  const [courses, setCourses] = useState<TimetableCourse[]>([]);
+  const [term, setTerm] = useState<Term>('202205');
+
+  useEffect(() => {
+    if (data) {
+      setCourses((data as Timetable).courses);
+      setTerm((data as Timetable).term);
+    }
+  }, [data]);
 
   const left = (
     <>
       <TopBar>Timetable Actions</TopBar>
       <TimetableActionButtons data={data as Timetable} loading={loading} />
+      {smallScreen && <TimetableCourseTags courses={courses} term={term} />}
     </>
   );
 
-  const right = (
+  const right = !smallScreen ? (
     <>
       <TopBar>Included Courses</TopBar>
       <Box h="100%" overflowY="auto" pb="20">
         {!loading && data && (
           <VStack>
-            {(data as Timetable).courses.map((course) => (
-              <TimetableCourseCard course={course} term={(data as Timetable).term} />
+            {courses.map((course) => (
+              <TimetableCourseCard course={course} term={term} />
             ))}
           </VStack>
         )}
       </Box>
     </>
-  );
+  ) : undefined;
 
   const calendarComponent = <ImportCalendar timetableCourses={data as Timetable} />;
   const listView = (
     <Sidebar>
       <VStack pb="60">
-        {!loading &&
-          data &&
-          (data as Timetable).courses.map((course) => (
-            <TimetableCourseCard course={course} term={(data as Timetable).term} />
-          ))}
+        {!loading && data && courses.map((course) => <TimetableCourseCard course={course} term={term} />)}
       </VStack>
     </Sidebar>
   );
@@ -63,25 +70,22 @@ export function ImportTimetable(): JSX.Element {
       {smallScreen ? (
         <VStack pt={2} w="100%" h="100%" overflow="hidden" flexGrow={1} px="3">
           <HStack justify="space-between" w="100%">
-            <Heading>{!loading && data ? getReadableTerm((data as Timetable).term) : 'Viewing Timetable'}</Heading>
+            <Heading>{!loading && data ? getReadableTerm(term) : 'Viewing Timetable'}</Heading>
             <ButtonGroup isAttached colorScheme="green">
               <Button isActive={!calendarView} onClick={() => setCalendarView(false)}>
                 List
               </Button>
-              <Button onClick={() => setCalendarView(true)}>Calendar</Button>
+              <Button isActive={calendarView} onClick={() => setCalendarView(true)}>
+                Calendar
+              </Button>
             </ButtonGroup>
           </HStack>
-          <Box w="100%">
-            <TimetableActionButtons loading={loading} data={data as Timetable} />
-          </Box>
           {!loading && data ? calendarView ? calendarComponent : listView : <Spinner size="xl" />}
         </VStack>
       ) : (
         <VStack pt={2} w="100%" height="100%" overflow="hidden" flexGrow={1}>
           <Heading textAlign="center">
-            {!loading && data
-              ? 'Viewing Timetable for ' + getReadableTerm((data as Timetable).term)
-              : 'Viewing Timetable'}
+            {!loading && data ? 'Viewing Timetable for ' + getReadableTerm(term) : 'Viewing Timetable'}
           </Heading>
           <Flex w="100%" height="100%">
             {!loading && data ? (


### PR DESCRIPTION
# Description

Proposal for fixing visual layout of import page on mobile to make use of sidebars and remove redundant buttons.
Removing right sidebar, as it simply showed list of courses, which is accessible on main page. Also added timetable tags to the left sidebar along with the actions.

## Screenshots

### Before
<img width="250" alt="image" src="https://user-images.githubusercontent.com/50898635/178091389-813bd56e-10b3-4b2b-8ee8-ee2783f45c4a.png">
<img width="250" alt="image" src="https://user-images.githubusercontent.com/50898635/178091393-5013ab2f-84b5-4ef2-9aaa-ea46b1596f3b.png">
<img width="250" alt="image" src="https://user-images.githubusercontent.com/50898635/178091395-23e8687e-2ef0-475c-ba4a-3d6f626a0cca.png">

### After
<img width="250" alt="image" src="https://user-images.githubusercontent.com/50898635/178091560-8736950e-e9bd-44e7-bd9d-bb46586746a7.png">
<img width="250" alt="image" src="https://user-images.githubusercontent.com/50898635/178091440-7973b529-fd46-448d-87ab-aa26bb31fa90.png">
<img width="250" alt="image" src="https://user-images.githubusercontent.com/50898635/178091571-95ccce4a-d620-4a85-bbdd-109859d7caa0.png">

## Checklist

- [x] The code follows all style guidelines.
- [x] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.

## General Comments

Would it be useful to add timetable cards underneath for "Your Timetable Courses" to show the user what they have saved currently?