### PR TITLE
fix: add more spacing between list items to increase readability

### DIFF
--- a/src/pages/registration/components/RegistrationHeading.tsx
+++ b/src/pages/registration/components/RegistrationHeading.tsx
@@ -30,7 +30,7 @@ export function RegistrationHeading() {
         <Text w="100%" textAlign="left">
           UVic offers a quick and easy way to register for a course using the Course Reference Number (CRN). Follow the
           given steps below to register in your chosen course sections:{' '}
-          <OrderedList mt="1" ml="6" mb="1">
+          <OrderedList mt="1" ml="8" mb="1" lineHeight={30}>
             <ListItem>
               Click the{' '}
               <Text as="span" fontWeight="bold">

--- a/src/pages/registration/components/RegistrationHeading.tsx
+++ b/src/pages/registration/components/RegistrationHeading.tsx
@@ -26,63 +26,71 @@ export function RegistrationHeading() {
         </Button>
       </Flex>
       <Divider my="4" />
-      <Flex>
+      <Flex flexDirection="column">
         <Text w="100%" textAlign="left">
           UVic offers a quick and easy way to register for a course using the Course Reference Number (CRN). Follow the
           given steps below to register in your chosen course sections:{' '}
-          <OrderedList mt="1" ml="8" mb="1" lineHeight={30}>
-            <ListItem>
-              Click the{' '}
-              <Text as="span" fontWeight="bold">
-                UVic Registration Page
-              </Text>{' '}
-              button.
-            </ListItem>
-            <ListItem>
-              Select the{' '}
-              <Text as="span" fontWeight="bold">
-                Manage registration
-              </Text>{' '}
-              page.
-            </ListItem>
-            <ListItem>Sign in to UVic with your NetLink ID.</ListItem>
-            <ListItem>
-              Select the appropriate term and hit{' '}
-              <Text as="span" fontWeight="bold">
-                Continue
-              </Text>
-              .
-            </ListItem>
-            <ListItem>
-              Select the{' '}
-              <Text as="span" fontWeight="bold">
-                Enter CRNs
-              </Text>{' '}
-              tab.
-            </ListItem>
-            <ListItem>
-              <Text as="span" fontWeight="bold">
-                {' '}
-                Copy <Icon as={IoCopyOutline} />{' '}
-              </Text>{' '}
-              and paste the CRNs into the input fields on the page, pressing{' '}
-              <Text as="span" fontWeight="bold">
-                Add Another CRN
-              </Text>{' '}
-              to add each of your courses.
-            </ListItem>
-            <ListItem>
-              Hit{' '}
-              <Text as="span" fontWeight="bold">
-                Add to Summary
-              </Text>{' '}
-              and then press the{' '}
-              <Text as="span" fontWeight="bold">
-                Submit
-              </Text>{' '}
-              button on the bottom right of the page, and you're registered!
-            </ListItem>
-          </OrderedList>
+        </Text>
+        <OrderedList
+          textAlign="left"
+          mt="2"
+          ml={{ base: '10', md: '12' }}
+          mb="2"
+          lineHeight={{ base: '24px', md: '30px' }}
+        >
+          <ListItem>
+            Click the{' '}
+            <Text as="span" fontWeight="bold">
+              UVic Registration Page
+            </Text>{' '}
+            button.
+          </ListItem>
+          <ListItem>
+            Select the{' '}
+            <Text as="span" fontWeight="bold">
+              Manage registration
+            </Text>{' '}
+            page.
+          </ListItem>
+          <ListItem>Sign in to UVic with your NetLink ID.</ListItem>
+          <ListItem>
+            Select the appropriate term and hit{' '}
+            <Text as="span" fontWeight="bold">
+              Continue
+            </Text>
+            .
+          </ListItem>
+          <ListItem>
+            Select the{' '}
+            <Text as="span" fontWeight="bold">
+              Enter CRNs
+            </Text>{' '}
+            tab.
+          </ListItem>
+          <ListItem>
+            <Text as="span" fontWeight="bold">
+              {' '}
+              Copy <Icon as={IoCopyOutline} />{' '}
+            </Text>{' '}
+            and paste the CRNs into the input fields on the page, pressing{' '}
+            <Text as="span" fontWeight="bold">
+              Add Another CRN
+            </Text>{' '}
+            to add each of your courses.
+          </ListItem>
+          <ListItem>
+            Hit{' '}
+            <Text as="span" fontWeight="bold">
+              Add to Summary
+            </Text>{' '}
+            and then press the{' '}
+            <Text as="span" fontWeight="bold">
+              Submit
+            </Text>{' '}
+            button on the bottom right of the page, and you're registered!
+          </ListItem>
+        </OrderedList>
+        <Text w="100%" textAlign="left">
           For more information, visit UVic's guide on "
           <Text as="span" color="blue.500" fontWeight="light">
             <Text
@@ -97,7 +105,7 @@ export function RegistrationHeading() {
           ."
         </Text>
       </Flex>
-      <Alert status="warning" borderRadius="10px" my={2}>
+      <Alert status="warning" borderRadius="10px" my={2} textAlign="left">
         <AlertIcon />
         Make sure to review all course prerequisites in the UVic Calendar before registering.
       </Alert>


### PR DESCRIPTION
# Description

Added more spacing between list items on the registration page to increase visibility.

Removed `<ol></ol>` from inside `<p></p>`.

## Screenshots

<img width="617" alt="spacing-between-the-list-entries" src="https://user-images.githubusercontent.com/10472448/179369163-bbf57f82-7947-4919-8f76-bc69d651c53a.png">

### Before

<img width="1000" alt="Capture d’écran, le 2022-07-16 à 13 09 15" src="https://user-images.githubusercontent.com/10472448/179370625-efa5a278-fefc-4e57-9add-3057e4780b05.png">

<img width="350" alt="Capture d’écran, le 2022-07-16 à 13 09 25" src="https://user-images.githubusercontent.com/10472448/179370627-6b574e77-513d-49e5-bfc1-708f8a6ac828.png">

### After

<img width="1000" alt="Capture d’écran, le 2022-07-16 à 13 09 10" src="https://user-images.githubusercontent.com/10472448/179370641-f4c079b8-cf6f-456e-815e-3eb27efb5f6b.png">

<img width="350" alt="Capture d’écran, le 2022-07-16 à 13 09 48" src="https://user-images.githubusercontent.com/10472448/179370642-24a18f9d-779e-48be-b19c-4cf21eb3966c.png">


## Checklist

- [X] The code follows all style guidelines.
- [ ] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [X] I have self-reviewed my changes and have done QA.

## General Comments

https://stackoverflow.com/a/5681796 to learn more about `p` and `ol` tags.
