### PR TITLE
Fix seats not loading cause of problems with /seats endpoint

### DIFF
--- a/functions/build/swagger.json
+++ b/functions/build/swagger.json
@@ -1,1333 +1,1189 @@
 {
-	"components": {
-		"examples": {},
-		"headers": {},
-		"parameters": {},
-		"requestBodies": {},
-		"responses": {},
-		"schemas": {
-			"Course": {
-				"properties": {
-					"pid": {
-						"type": "string"
-					},
-					"title": {
-						"type": "string"
-					},
-					"subject": {
-						"type": "string"
-					},
-					"code": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"pid",
-					"title",
-					"subject",
-					"code"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Term": {
-				"type": "string",
-				"enum": [
-					"202001",
-					"202005",
-					"202009",
-					"202101",
-					"202105",
-					"202109",
-					"202201",
-					"202205",
-					"202209",
-					"202301"
-				]
-			},
-			"NestedPreCoRequisites": {
-				"properties": {
-					"reqList": {
-						"items": {
-							"anyOf": [
-								{
-									"$ref": "#/components/schemas/NestedPreCoRequisites"
-								},
-								{
-									"$ref": "#/components/schemas/KualiCourse"
-								},
-								{
-									"type": "string"
-								}
-							]
-						},
-						"type": "array"
-					},
-					"unparsed": {
-						"type": "string"
-					},
-					"gpa": {
-						"type": "string"
-					},
-					"grade": {
-						"type": "string"
-					},
-					"units": {
-						"type": "boolean"
-					},
-					"coreq": {
-						"type": "boolean"
-					},
-					"quantity": {
-						"anyOf": [
-							{
-								"type": "number",
-								"format": "double"
-							},
-							{
-								"type": "string",
-								"enum": [
-									"ALL"
-								]
-							}
-						]
-					}
-				},
-				"type": "object"
-			},
-			"KualiCourse": {
-				"properties": {
-					"pid": {
-						"type": "string"
-					},
-					"code": {
-						"type": "string"
-					},
-					"subject": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"code",
-					"subject"
-				],
-				"type": "object"
-			},
-			"CourseDetails": {
-				"properties": {
-					"pid": {
-						"type": "string"
-					},
-					"title": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"dateStart": {
-						"type": "string"
-					},
-					"credits": {
-						"properties": {
-							"chosen": {
-								"type": "string"
-							},
-							"value": {
-								"anyOf": [
-									{
-										"type": "string"
-									},
-									{
-										"properties": {
-											"max": {
-												"type": "string"
-											},
-											"min": {
-												"type": "string"
-											}
-										},
-										"required": [
-											"max",
-											"min"
-										],
-										"type": "object"
-									}
-								]
-							},
-							"credits": {
-								"properties": {
-									"max": {
-										"type": "string"
-									},
-									"min": {
-										"type": "string"
-									}
-								},
-								"required": [
-									"max",
-									"min"
-								],
-								"type": "object"
-							}
-						},
-						"required": [
-							"chosen",
-							"value",
-							"credits"
-						],
-						"type": "object"
-					},
-					"hoursCatalog": {
-						"items": {
-							"properties": {
-								"lab": {
-									"type": "string"
-								},
-								"tutorial": {
-									"type": "string"
-								},
-								"lecture": {
-									"type": "string"
-								}
-							},
-							"required": [
-								"lab",
-								"tutorial",
-								"lecture"
-							],
-							"type": "object"
-						},
-						"type": "array"
-					},
-					"preAndCorequisites": {
-						"items": {
-							"anyOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/components/schemas/NestedPreCoRequisites"
-								},
-								{
-									"$ref": "#/components/schemas/KualiCourse"
-								}
-							]
-						},
-						"type": "array"
-					},
-					"preOrCorequisites": {
-						"items": {
-							"anyOf": [
-								{
-									"type": "string"
-								},
-								{
-									"$ref": "#/components/schemas/NestedPreCoRequisites"
-								},
-								{
-									"$ref": "#/components/schemas/KualiCourse"
-								}
-							]
-						},
-						"type": "array"
-					},
-					"subject": {
-						"type": "string",
-						"description": "Abbriviation of the subject of the course.",
-						"example": "ECE"
-					},
-					"code": {
-						"type": "string",
-						"description": "The code portion of the course.",
-						"example": "260"
-					},
-					"formally": {
-						"type": "string",
-						"description": "If a course was named something else previously.",
-						"example": "ELEC260"
-					}
-				},
-				"required": [
-					"pid",
-					"title",
-					"description",
-					"dateStart",
-					"credits",
-					"subject",
-					"code"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"EventRequest": {
-				"properties": {
-					"name": {
-						"type": "string"
-					}
-				},
-				"additionalProperties": {},
-				"required": [
-					"name"
-				],
-				"type": "object"
-			},
-			"levelType": {
-				"type": "string",
-				"enum": [
-					"law",
-					"undergraduate",
-					"graduate"
-				]
-			},
-			"sectionType": {
-				"type": "string",
-				"enum": [
-					"lecture",
-					"lab",
-					"tutorial",
-					"gradable lab",
-					"lecture topic"
-				]
-			},
-			"Pick_ClassScheduleListing.Exclude_keyofClassScheduleListing.meetingTimes__": {
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"crn": {
-						"type": "string"
-					},
-					"sectionCode": {
-						"type": "string"
-					},
-					"additionalNotes": {
-						"type": "string"
-					},
-					"associatedTerm": {
-						"properties": {
-							"end": {
-								"type": "string"
-							},
-							"start": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"end",
-							"start"
-						],
-						"type": "object"
-					},
-					"registrationDates": {
-						"properties": {
-							"end": {
-								"type": "string"
-							},
-							"start": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"end",
-							"start"
-						],
-						"type": "object"
-					},
-					"levels": {
-						"items": {
-							"$ref": "#/components/schemas/levelType"
-						},
-						"type": "array"
-					},
-					"campus": {
-						"type": "string",
-						"enum": [
-							"online",
-							"in-person"
-						]
-					},
-					"sectionType": {
-						"$ref": "#/components/schemas/sectionType"
-					},
-					"instructionalMethod": {
-						"type": "string"
-					},
-					"credits": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"title",
-					"crn",
-					"sectionCode",
-					"associatedTerm",
-					"registrationDates",
-					"levels",
-					"campus",
-					"sectionType",
-					"instructionalMethod",
-					"credits"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"Omit_ClassScheduleListing.meetingTimes_": {
-				"$ref": "#/components/schemas/Pick_ClassScheduleListing.Exclude_keyofClassScheduleListing.meetingTimes__",
-				"description": "Construct a type with the properties of T except for those in type K."
-			},
-			"MeetingTimes": {
-				"properties": {
-					"roomNumber": {
-						"type": "string"
-					},
-					"buildingAbbreviation": {
-						"type": "string"
-					},
-					"building": {
-						"type": "string"
-					},
-					"instructors": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"scheduleType": {
-						"type": "string"
-					},
-					"dateRange": {
-						"type": "string"
-					},
-					"where": {
-						"type": "string"
-					},
-					"days": {
-						"type": "string"
-					},
-					"time": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"instructors",
-					"scheduleType",
-					"dateRange",
-					"where",
-					"days",
-					"time",
-					"type"
-				],
-				"type": "object"
-			},
-			"Section": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/Omit_ClassScheduleListing.meetingTimes_"
-					},
-					{
-						"properties": {
-							"seats": {
-								"properties": {
-									"waitAvailable": {
-										"type": "number",
-										"format": "double",
-										"nullable": true
-									},
-									"waitCount": {
-										"type": "number",
-										"format": "double"
-									},
-									"waitCapacity": {
-										"type": "number",
-										"format": "double",
-										"nullable": true
-									},
-									"seatsAvailable": {
-										"type": "number",
-										"format": "double"
-									},
-									"enrollment": {
-										"type": "number",
-										"format": "double"
-									},
-									"maxEnrollment": {
-										"type": "number",
-										"format": "double"
-									}
-								},
-								"required": [
-									"waitAvailable",
-									"waitCount",
-									"waitCapacity",
-									"seatsAvailable",
-									"enrollment",
-									"maxEnrollment"
-								],
-								"type": "object"
-							},
-							"meetingTimes": {
-								"items": {
-									"$ref": "#/components/schemas/MeetingTimes"
-								},
-								"type": "array"
-							}
-						},
-						"required": [
-							"meetingTimes"
-						],
-						"type": "object"
-					}
-				]
-			},
-			"Seating": {
-				"properties": {
-					"capacity": {
-						"type": "number",
-						"format": "double"
-					},
-					"actual": {
-						"type": "number",
-						"format": "double"
-					},
-					"remaining": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"capacity",
-					"actual",
-					"remaining"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"classification": {
-				"type": "string",
-				"enum": [
-					"YEAR_1",
-					"YEAR_2",
-					"YEAR_3",
-					"YEAR_4",
-					"YEAR_5",
-					"unclassified"
-				]
-			},
-			"Requirements": {
-				"properties": {
-					"level": {
-						"items": {
-							"$ref": "#/components/schemas/levelType"
-						},
-						"type": "array"
-					},
-					"fieldOfStudy": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"classification": {
-						"items": {
-							"$ref": "#/components/schemas/classification"
-						},
-						"type": "array"
-					},
-					"negClassification": {
-						"items": {
-							"$ref": "#/components/schemas/classification"
-						},
-						"type": "array"
-					},
-					"degree": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"program": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"negProgram": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"college": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"negCollege": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"major": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"level"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Seat": {
-				"properties": {
-					"title": {
-						"type": "string"
-					},
-					"seats": {
-						"$ref": "#/components/schemas/Seating"
-					},
-					"waitListSeats": {
-						"$ref": "#/components/schemas/Seating"
-					},
-					"requirements": {
-						"$ref": "#/components/schemas/Requirements"
-					},
-					"crn": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"title",
-					"seats",
-					"waitListSeats",
-					"crn"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"KualiSubject": {
-				"properties": {
-					"subject": {
-						"type": "string"
-					},
-					"title": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"subject",
-					"title"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Subject": {
-				"$ref": "#/components/schemas/KualiSubject"
-			},
-			"ExtendedTextbook": {
-				"properties": {
-					"instructor": {
-						"type": "string"
-					},
-					"isbn": {
-						"type": "string"
-					},
-					"price": {
-						"properties": {
-							"newAndDigitalAccessCad": {
-								"type": "string"
-							},
-							"digitalAccessCad": {
-								"type": "string"
-							},
-							"usedCad": {
-								"type": "string"
-							},
-							"newCad": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"required": {
-						"type": "boolean"
-					},
-					"authors": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"title": {
-						"type": "string"
-					},
-					"imageUrl": {
-						"type": "string"
-					},
-					"bookstoreUrl": {
-						"type": "string"
-					},
-					"amazonUrl": {
-						"type": "string"
-					},
-					"isbn10": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"price",
-					"required",
-					"title"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"CourseTextbook": {
-				"properties": {
-					"textbooks": {
-						"items": {
-							"$ref": "#/components/schemas/ExtendedTextbook"
-						},
-						"type": "array"
-					},
-					"instructor": {
-						"type": "string"
-					},
-					"additionalInfo": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"section": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"textbooks"
-				],
-				"type": "object"
-			},
-			"TextbookInfo": {
-				"properties": {
-					"subject": {
-						"type": "string"
-					},
-					"code": {
-						"type": "string"
-					},
-					"term": {
-						"type": "string"
-					},
-					"sections": {
-						"items": {
-							"$ref": "#/components/schemas/CourseTextbook"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"subject",
-					"code",
-					"term",
-					"sections"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TimetableCourse": {
-				"properties": {
-					"color": {
-						"type": "string",
-						"description": "The colour code displayed on the timetable",
-						"example": "#123456",
-						"pattern": "^#(?:[0-9a-fA-F]{3}){1,2}$"
-					},
-					"tutorial": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"description": "The selected tutorial section of the course.",
-						"example": "T03",
-						"pattern": "^T\\d{2}$"
-					},
-					"lab": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"description": "The selected lab section of the course.",
-						"example": "B01",
-						"pattern": "^B\\d{2}$"
-					},
-					"lecture": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"description": "The selected lecture section of the course.",
-						"example": "A02",
-						"pattern": "^A\\d{2}$"
-					},
-					"pid": {
-						"type": "string",
-						"description": "The PID of the course.",
-						"example": "ByS23Pp7E"
-					},
-					"code": {
-						"type": "string",
-						"description": "The code portion of the course.",
-						"example": "260"
-					},
-					"subject": {
-						"type": "string",
-						"description": "Abbreviation of the subject of the course.",
-						"example": "ECE"
-					}
-				},
-				"required": [
-					"color",
-					"pid",
-					"code",
-					"subject"
-				],
-				"type": "object"
-			},
-			"Timetable": {
-				"properties": {
-					"courses": {
-						"items": {
-							"$ref": "#/components/schemas/TimetableCourse"
-						},
-						"type": "array"
-					},
-					"term": {
-						"$ref": "#/components/schemas/Term"
-					}
-				},
-				"required": [
-					"courses",
-					"term"
-				],
-				"type": "object"
-			},
-			"TimetableReturn": {
-				"allOf": [
-					{
-						"properties": {
-							"slug": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"slug"
-						],
-						"type": "object"
-					},
-					{
-						"$ref": "#/components/schemas/Timetable"
-					}
-				]
-			},
-			"ValidateErrorJSON": {
-				"properties": {
-					"message": {
-						"type": "string",
-						"enum": [
-							"Validation failed"
-						],
-						"nullable": false
-					},
-					"details": {
-						"properties": {},
-						"additionalProperties": {},
-						"type": "object"
-					}
-				},
-				"required": [
-					"message",
-					"details"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Pick_Timetable.courses-or-term_": {
-				"properties": {
-					"courses": {
-						"items": {
-							"$ref": "#/components/schemas/TimetableCourse"
-						},
-						"type": "array"
-					},
-					"term": {
-						"$ref": "#/components/schemas/Term"
-					}
-				},
-				"required": [
-					"courses",
-					"term"
-				],
-				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
-			},
-			"TimetableParams": {
-				"$ref": "#/components/schemas/Pick_Timetable.courses-or-term_"
-			}
-		},
-		"securitySchemes": {}
-	},
-	"info": {
-		"title": "functions",
-		"contact": {}
-	},
-	"openapi": "3.0.0",
-	"paths": {
-		"/courses/{term}": {
-			"get": {
-				"operationId": "GetCourses",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/Course"
-									},
-									"type": "array"
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieves all the courses available. If query params are passed in, they will be used to filter results.",
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "term",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/Term"
-						}
-					},
-					{
-						"in": "query",
-						"name": "in_session",
-						"required": false,
-						"schema": {
-							"default": false,
-							"type": "boolean"
-						}
-					}
-				]
-			}
-		},
-		"/courses/{term}/{pid}": {
-			"get": {
-				"operationId": "GetCourse",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/CourseDetails"
-								}
-							}
-						}
-					}
-				},
-				"description": "Retrieves course details given the term and pid.",
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "pid",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "path",
-						"name": "term",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/Term"
-						}
-					}
-				]
-			}
-		},
-		"/courses/{term}/{subject}/{code}": {
-			"get": {
-				"operationId": "GetCourseDetails",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/CourseDetails"
-								}
-							}
-						}
-					}
-				},
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "term",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/Term"
-						}
-					},
-					{
-						"in": "path",
-						"name": "subject",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "path",
-						"name": "code",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/events": {
-			"post": {
-				"operationId": "PostEvent",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"success": {
-											"type": "boolean"
-										}
-									},
-									"required": [
-										"success"
-									],
-									"type": "object"
-								}
-							}
-						}
-					}
-				},
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/EventRequest"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/sections/{term}": {
-			"get": {
-				"operationId": "Sections",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/Section"
-									},
-									"type": "array"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Section Not Found"
-					}
-				},
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "term",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/Term"
-						}
-					},
-					{
-						"in": "query",
-						"name": "subject",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "query",
-						"name": "code",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "query",
-						"name": "v9",
-						"required": false,
-						"schema": {
-							"default": false,
-							"type": "boolean"
-						}
-					}
-				]
-			}
-		},
-		"/sections/{term}/seats": {
-			"get": {
-				"operationId": "Seats",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/Seat"
-									},
-									"type": "array"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Section Seats Not Found"
-					}
-				},
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "term",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/Term"
-						}
-					},
-					{
-						"in": "query",
-						"name": "subject",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "query",
-						"name": "code",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/subjects/{term}": {
-			"get": {
-				"operationId": "Subjects",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/Subject"
-									},
-									"type": "array"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"Subjects"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "term",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/Term"
-						}
-					}
-				]
-			}
-		},
-		"/textbooks/{term}/{subject}/{code}": {
-			"get": {
-				"operationId": "GetTextbooks",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"anyOf": [
-										{
-											"$ref": "#/components/schemas/TextbookInfo"
-										},
-										{}
-									]
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Textbooks Not Found"
-					}
-				},
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "term",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/Term"
-						}
-					},
-					{
-						"in": "path",
-						"name": "subject",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"in": "path",
-						"name": "code",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/timetables/{slug}": {
-			"get": {
-				"operationId": "GetTimetable",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"anyOf": [
-										{
-											"$ref": "#/components/schemas/Timetable"
-										},
-										{}
-									]
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Not found"
-					}
-				},
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "slug",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/timetables": {
-			"put": {
-				"operationId": "CreateTimetable",
-				"responses": {
-					"201": {
-						"description": "Created",
-						"content": {
-							"application/json": {
-								"schema": {
-									"anyOf": [
-										{
-											"$ref": "#/components/schemas/TimetableReturn"
-										},
-										{}
-									]
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Invalid data",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidateErrorJSON"
-								}
-							}
-						}
-					}
-				},
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/TimetableParams"
-							}
-						}
-					}
-				}
-			}
-		}
-	},
-	"servers": [
-		{
-			"url": "/"
-		}
-	]
+  "components": {
+    "examples": {},
+    "headers": {},
+    "parameters": {},
+    "requestBodies": {},
+    "responses": {},
+    "schemas": {
+      "Course": {
+        "properties": {
+          "pid": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "required": ["pid", "title", "subject", "code"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Term": {
+        "type": "string",
+        "enum": [
+          "202001",
+          "202005",
+          "202009",
+          "202101",
+          "202105",
+          "202109",
+          "202201",
+          "202205",
+          "202209",
+          "202301"
+        ]
+      },
+      "NestedPreCoRequisites": {
+        "properties": {
+          "reqList": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/NestedPreCoRequisites"
+                },
+                {
+                  "$ref": "#/components/schemas/KualiCourse"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "unparsed": {
+            "type": "string"
+          },
+          "gpa": {
+            "type": "string"
+          },
+          "grade": {
+            "type": "string"
+          },
+          "units": {
+            "type": "boolean"
+          },
+          "coreq": {
+            "type": "boolean"
+          },
+          "quantity": {
+            "anyOf": [
+              {
+                "type": "number",
+                "format": "double"
+              },
+              {
+                "type": "string",
+                "enum": ["ALL"]
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "KualiCourse": {
+        "properties": {
+          "pid": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "subject"],
+        "type": "object"
+      },
+      "CourseDetails": {
+        "properties": {
+          "pid": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "dateStart": {
+            "type": "string"
+          },
+          "credits": {
+            "properties": {
+              "chosen": {
+                "type": "string"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "max": {
+                        "type": "string"
+                      },
+                      "min": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["max", "min"],
+                    "type": "object"
+                  }
+                ]
+              },
+              "credits": {
+                "properties": {
+                  "max": {
+                    "type": "string"
+                  },
+                  "min": {
+                    "type": "string"
+                  }
+                },
+                "required": ["max", "min"],
+                "type": "object"
+              }
+            },
+            "required": ["chosen", "value", "credits"],
+            "type": "object"
+          },
+          "hoursCatalog": {
+            "items": {
+              "properties": {
+                "lab": {
+                  "type": "string"
+                },
+                "tutorial": {
+                  "type": "string"
+                },
+                "lecture": {
+                  "type": "string"
+                }
+              },
+              "required": ["lab", "tutorial", "lecture"],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "preAndCorequisites": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/NestedPreCoRequisites"
+                },
+                {
+                  "$ref": "#/components/schemas/KualiCourse"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "preOrCorequisites": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/NestedPreCoRequisites"
+                },
+                {
+                  "$ref": "#/components/schemas/KualiCourse"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "subject": {
+            "type": "string",
+            "description": "Abbriviation of the subject of the course.",
+            "example": "ECE"
+          },
+          "code": {
+            "type": "string",
+            "description": "The code portion of the course.",
+            "example": "260"
+          },
+          "formally": {
+            "type": "string",
+            "description": "If a course was named something else previously.",
+            "example": "ELEC260"
+          }
+        },
+        "required": [
+          "pid",
+          "title",
+          "description",
+          "dateStart",
+          "credits",
+          "subject",
+          "code"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "EventRequest": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": {},
+        "required": ["name"],
+        "type": "object"
+      },
+      "levelType": {
+        "type": "string",
+        "enum": ["law", "undergraduate", "graduate"]
+      },
+      "sectionType": {
+        "type": "string",
+        "enum": ["lecture", "lab", "tutorial", "gradable lab", "lecture topic"]
+      },
+      "Pick_ClassScheduleListing.Exclude_keyofClassScheduleListing.meetingTimes__": {
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "crn": {
+            "type": "string"
+          },
+          "sectionCode": {
+            "type": "string"
+          },
+          "additionalNotes": {
+            "type": "string"
+          },
+          "associatedTerm": {
+            "properties": {
+              "end": {
+                "type": "string"
+              },
+              "start": {
+                "type": "string"
+              }
+            },
+            "required": ["end", "start"],
+            "type": "object"
+          },
+          "registrationDates": {
+            "properties": {
+              "end": {
+                "type": "string"
+              },
+              "start": {
+                "type": "string"
+              }
+            },
+            "required": ["end", "start"],
+            "type": "object"
+          },
+          "levels": {
+            "items": {
+              "$ref": "#/components/schemas/levelType"
+            },
+            "type": "array"
+          },
+          "campus": {
+            "type": "string",
+            "enum": ["online", "in-person"]
+          },
+          "sectionType": {
+            "$ref": "#/components/schemas/sectionType"
+          },
+          "instructionalMethod": {
+            "type": "string"
+          },
+          "credits": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "crn",
+          "sectionCode",
+          "associatedTerm",
+          "registrationDates",
+          "levels",
+          "campus",
+          "sectionType",
+          "instructionalMethod",
+          "credits"
+        ],
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "Omit_ClassScheduleListing.meetingTimes_": {
+        "$ref": "#/components/schemas/Pick_ClassScheduleListing.Exclude_keyofClassScheduleListing.meetingTimes__",
+        "description": "Construct a type with the properties of T except for those in type K."
+      },
+      "MeetingTimes": {
+        "properties": {
+          "roomNumber": {
+            "type": "string"
+          },
+          "buildingAbbreviation": {
+            "type": "string"
+          },
+          "building": {
+            "type": "string"
+          },
+          "instructors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "scheduleType": {
+            "type": "string"
+          },
+          "dateRange": {
+            "type": "string"
+          },
+          "where": {
+            "type": "string"
+          },
+          "days": {
+            "type": "string"
+          },
+          "time": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "instructors",
+          "scheduleType",
+          "dateRange",
+          "where",
+          "days",
+          "time",
+          "type"
+        ],
+        "type": "object"
+      },
+      "Section": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Omit_ClassScheduleListing.meetingTimes_"
+          },
+          {
+            "properties": {
+              "seats": {
+                "properties": {
+                  "waitAvailable": {
+                    "type": "number",
+                    "format": "double",
+                    "nullable": true
+                  },
+                  "waitCount": {
+                    "type": "number",
+                    "format": "double"
+                  },
+                  "waitCapacity": {
+                    "type": "number",
+                    "format": "double",
+                    "nullable": true
+                  },
+                  "seatsAvailable": {
+                    "type": "number",
+                    "format": "double"
+                  },
+                  "enrollment": {
+                    "type": "number",
+                    "format": "double"
+                  },
+                  "maxEnrollment": {
+                    "type": "number",
+                    "format": "double"
+                  }
+                },
+                "required": [
+                  "waitAvailable",
+                  "waitCount",
+                  "waitCapacity",
+                  "seatsAvailable",
+                  "enrollment",
+                  "maxEnrollment"
+                ],
+                "type": "object"
+              },
+              "meetingTimes": {
+                "items": {
+                  "$ref": "#/components/schemas/MeetingTimes"
+                },
+                "type": "array"
+              }
+            },
+            "required": ["meetingTimes"],
+            "type": "object"
+          }
+        ]
+      },
+      "Seating": {
+        "properties": {
+          "capacity": {
+            "type": "number",
+            "format": "double"
+          },
+          "actual": {
+            "type": "number",
+            "format": "double"
+          },
+          "remaining": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": ["capacity", "actual", "remaining"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "classification": {
+        "type": "string",
+        "enum": [
+          "YEAR_1",
+          "YEAR_2",
+          "YEAR_3",
+          "YEAR_4",
+          "YEAR_5",
+          "unclassified"
+        ]
+      },
+      "Requirements": {
+        "properties": {
+          "level": {
+            "items": {
+              "$ref": "#/components/schemas/levelType"
+            },
+            "type": "array"
+          },
+          "fieldOfStudy": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "classification": {
+            "items": {
+              "$ref": "#/components/schemas/classification"
+            },
+            "type": "array"
+          },
+          "negClassification": {
+            "items": {
+              "$ref": "#/components/schemas/classification"
+            },
+            "type": "array"
+          },
+          "degree": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "program": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "negProgram": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "college": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "negCollege": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "major": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["level"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Seat": {
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "seats": {
+            "$ref": "#/components/schemas/Seating"
+          },
+          "waitListSeats": {
+            "$ref": "#/components/schemas/Seating"
+          },
+          "requirements": {
+            "$ref": "#/components/schemas/Requirements"
+          },
+          "crn": {
+            "type": "string"
+          }
+        },
+        "required": ["title", "seats", "waitListSeats", "crn"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "KualiSubject": {
+        "properties": {
+          "subject": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": ["subject", "title"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Subject": {
+        "$ref": "#/components/schemas/KualiSubject"
+      },
+      "ExtendedTextbook": {
+        "properties": {
+          "instructor": {
+            "type": "string"
+          },
+          "isbn": {
+            "type": "string"
+          },
+          "price": {
+            "properties": {
+              "newAndDigitalAccessCad": {
+                "type": "string"
+              },
+              "digitalAccessCad": {
+                "type": "string"
+              },
+              "usedCad": {
+                "type": "string"
+              },
+              "newCad": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "authors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "title": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "bookstoreUrl": {
+            "type": "string"
+          },
+          "amazonUrl": {
+            "type": "string"
+          },
+          "isbn10": {
+            "type": "string"
+          }
+        },
+        "required": ["price", "required", "title"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CourseTextbook": {
+        "properties": {
+          "textbooks": {
+            "items": {
+              "$ref": "#/components/schemas/ExtendedTextbook"
+            },
+            "type": "array"
+          },
+          "instructor": {
+            "type": "string"
+          },
+          "additionalInfo": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "section": {
+            "type": "string"
+          }
+        },
+        "required": ["textbooks"],
+        "type": "object"
+      },
+      "TextbookInfo": {
+        "properties": {
+          "subject": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "term": {
+            "type": "string"
+          },
+          "sections": {
+            "items": {
+              "$ref": "#/components/schemas/CourseTextbook"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["subject", "code", "term", "sections"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TimetableCourse": {
+        "properties": {
+          "color": {
+            "type": "string",
+            "description": "The colour code displayed on the timetable",
+            "example": "#123456",
+            "pattern": "^#(?:[0-9a-fA-F]{3}){1,2}$"
+          },
+          "tutorial": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "The selected tutorial section of the course.",
+            "example": "T03",
+            "pattern": "^T\\d{2}$"
+          },
+          "lab": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "The selected lab section of the course.",
+            "example": "B01",
+            "pattern": "^B\\d{2}$"
+          },
+          "lecture": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "The selected lecture section of the course.",
+            "example": "A02",
+            "pattern": "^A\\d{2}$"
+          },
+          "pid": {
+            "type": "string",
+            "description": "The PID of the course.",
+            "example": "ByS23Pp7E"
+          },
+          "code": {
+            "type": "string",
+            "description": "The code portion of the course.",
+            "example": "260"
+          },
+          "subject": {
+            "type": "string",
+            "description": "Abbreviation of the subject of the course.",
+            "example": "ECE"
+          }
+        },
+        "required": ["color", "pid", "code", "subject"],
+        "type": "object"
+      },
+      "Timetable": {
+        "properties": {
+          "courses": {
+            "items": {
+              "$ref": "#/components/schemas/TimetableCourse"
+            },
+            "type": "array"
+          },
+          "term": {
+            "$ref": "#/components/schemas/Term"
+          }
+        },
+        "required": ["courses", "term"],
+        "type": "object"
+      },
+      "TimetableReturn": {
+        "allOf": [
+          {
+            "properties": {
+              "slug": {
+                "type": "string"
+              }
+            },
+            "required": ["slug"],
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/Timetable"
+          }
+        ]
+      },
+      "ValidateErrorJSON": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "enum": ["Validation failed"],
+            "nullable": false
+          },
+          "details": {
+            "properties": {},
+            "additionalProperties": {},
+            "type": "object"
+          }
+        },
+        "required": ["message", "details"],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Pick_Timetable.courses-or-term_": {
+        "properties": {
+          "courses": {
+            "items": {
+              "$ref": "#/components/schemas/TimetableCourse"
+            },
+            "type": "array"
+          },
+          "term": {
+            "$ref": "#/components/schemas/Term"
+          }
+        },
+        "required": ["courses", "term"],
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "TimetableParams": {
+        "$ref": "#/components/schemas/Pick_Timetable.courses-or-term_"
+      }
+    },
+    "securitySchemes": {}
+  },
+  "info": {
+    "title": "functions",
+    "contact": {}
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/courses/{term}": {
+      "get": {
+        "operationId": "GetCourses",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Course"
+                  },
+                  "type": "array"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieves all the courses available. If query params are passed in, they will be used to filter results.",
+        "security": [],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "term",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Term"
+            }
+          },
+          {
+            "in": "query",
+            "name": "in_session",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        ]
+      }
+    },
+    "/courses/{term}/{pid}": {
+      "get": {
+        "operationId": "GetCourse",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseDetails"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieves course details given the term and pid.",
+        "security": [],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "term",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Term"
+            }
+          }
+        ]
+      }
+    },
+    "/courses/{term}/{subject}/{code}": {
+      "get": {
+        "operationId": "GetCourseDetails",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "term",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Term"
+            }
+          },
+          {
+            "in": "path",
+            "name": "subject",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/events": {
+      "post": {
+        "operationId": "PostEvent",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["success"],
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sections/{term}": {
+      "get": {
+        "operationId": "Sections",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Section"
+                  },
+                  "type": "array"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Section Not Found"
+          }
+        },
+        "security": [],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "term",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Term"
+            }
+          },
+          {
+            "in": "query",
+            "name": "subject",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "v9",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        ]
+      }
+    },
+    "/subjects/{term}": {
+      "get": {
+        "operationId": "Subjects",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Subject"
+                  },
+                  "type": "array"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Subjects"],
+        "security": [],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "term",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Term"
+            }
+          }
+        ]
+      }
+    },
+    "/textbooks/{term}/{subject}/{code}": {
+      "get": {
+        "operationId": "GetTextbooks",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/TextbookInfo"
+                    },
+                    {}
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Textbooks Not Found"
+          }
+        },
+        "security": [],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "term",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Term"
+            }
+          },
+          {
+            "in": "path",
+            "name": "subject",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/timetables/{slug}": {
+      "get": {
+        "operationId": "GetTimetable",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/Timetable"
+                    },
+                    {}
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "security": [],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/timetables": {
+      "put": {
+        "operationId": "CreateTimetable",
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/TimetableReturn"
+                    },
+                    {}
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Invalid data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidateErrorJSON"
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TimetableParams"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ]
 }

--- a/src/lib/fetchers.tsx
+++ b/src/lib/fetchers.tsx
@@ -393,30 +393,6 @@ export const useSections = ({ term, ...props }: UseSectionsProps) =>
     { pathParams: { term }, ...props }
   );
 
-export interface SeatsQueryParams {
-  subject: string;
-  code: string;
-}
-
-export interface SeatsPathParams {
-  term: Term;
-}
-
-export type SeatsProps = Omit<GetProps<Seat[], void, SeatsQueryParams, SeatsPathParams>, 'path'> & SeatsPathParams;
-
-export const Seats = ({ term, ...props }: SeatsProps) => (
-  <Get<Seat[], void, SeatsQueryParams, SeatsPathParams> path={`/sections/${term}/seats`} {...props} />
-);
-
-export type UseSeatsProps = Omit<UseGetProps<Seat[], void, SeatsQueryParams, SeatsPathParams>, 'path'> &
-  SeatsPathParams;
-
-export const useSeats = ({ term, ...props }: UseSeatsProps) =>
-  useGet<Seat[], void, SeatsQueryParams, SeatsPathParams>(
-    (paramsInPath: SeatsPathParams) => `/sections/${paramsInPath.term}/seats`,
-    { pathParams: { term }, ...props }
-  );
-
 export interface SubjectsPathParams {
   term: Term;
 }

--- a/src/pages/calendar/containers/Section.tsx
+++ b/src/pages/calendar/containers/Section.tsx
@@ -1,6 +1,6 @@
 import { Box, Center, Divider, Heading, Spinner } from '@chakra-ui/react';
 
-import { Section, Seat, Term, useSeats, useSections } from 'lib/fetchers';
+import { Section, Seat, Term, useSections } from 'lib/fetchers';
 import { useDarkMode } from 'lib/hooks/useDarkMode';
 
 import { NotFound } from 'common/notFound/NotFound';
@@ -38,7 +38,27 @@ export function SectionsContainer({ term, subject, code }: SectionsContainerProp
     loading,
     error: sectionsError,
   } = useSections({ term, queryParams: { subject, code, v9: true } });
-  const { data: seats, error: seatsError } = useSeats({ term, queryParams: { subject, code } });
+
+  const seats = sections
+    ?.filter((e) => e.seats !== undefined)
+    .map(
+      (e) =>
+        ({
+          title: e.sectionType,
+          seats: {
+            capacity: e.seats?.maxEnrollment,
+            actual: e.seats?.enrollment,
+            remaining: e.seats?.seatsAvailable,
+          },
+          waitListSeats: {
+            capacity: e.seats?.waitCapacity,
+            actual: e.seats?.waitCount,
+            remaining: e.seats?.waitAvailable,
+          },
+          crn: e.crn,
+        } as Seat)
+    );
+
   const mode = useDarkMode();
 
   if (loading) {
@@ -50,7 +70,7 @@ export function SectionsContainer({ term, subject, code }: SectionsContainerProp
   }
 
   // we can't just look at sectionsError since it returns an empty array upon "not finding" any sections.
-  if (seatsError || sectionsError || sections?.length === 0 || seats?.length === 0) {
+  if (sectionsError || sections?.length === 0 || seats?.length === 0) {
     return <NotFound term={term}>No sections offered for</NotFound>;
   }
 

--- a/src/pages/registration/containers/CourseContainer.tsx
+++ b/src/pages/registration/containers/CourseContainer.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from '@chakra-ui/skeleton';
 import { Collapse } from '@chakra-ui/transition';
 import { useParams } from 'react-router';
 
-import { useSeats, useSections, Term, Seat } from 'lib/fetchers';
+import { useSections, Term, Seat } from 'lib/fetchers';
 import { useDarkMode } from 'lib/hooks/useDarkMode';
 import { SavedCourse } from 'lib/hooks/useSavedCourses';
 
@@ -33,10 +33,26 @@ export function CourseContainer({ course }: Props) {
     term: termType,
     queryParams: { subject: course.subject, code: course.code, v9: true },
   });
-  const { data: seats } = useSeats({
-    term: termType,
-    queryParams: { subject: course.subject, code: course.code },
-  });
+
+  const seats = sections
+    ?.filter((e) => e.seats !== undefined)
+    .map(
+      (e) =>
+        ({
+          title: e.sectionType,
+          seats: {
+            capacity: e.seats?.maxEnrollment,
+            actual: e.seats?.enrollment,
+            remaining: e.seats?.seatsAvailable,
+          },
+          waitListSeats: {
+            capacity: e.seats?.waitCapacity,
+            actual: e.seats?.waitCount,
+            remaining: e.seats?.waitAvailable,
+          },
+          crn: e.crn,
+        } as Seat)
+    );
 
   useEffect(() => {
     if (!loading) {


### PR DESCRIPTION
# Description

500 error response from /seats endpoint is causing none of the information for a course to show.

<img width="753" alt="image" src="https://user-images.githubusercontent.com/50898635/200190207-a8bfe079-ff9e-41b4-bf92-fc77ea13b181.png">

The seating data is currently coming through v9 object, so I just replaced the seats with a modified version of the data to match the expected type, and it seems to be working on my end.

I deleted the /seats config from swagger.json and regenerated `fetchers.tsx` with the `fetcher:generate` command.

## After
(No more /seats request)
<img width="756" alt="image" src="https://user-images.githubusercontent.com/50898635/200190359-799875ef-c9fe-4c46-8764-41dc9cc5ce06.png">


## Checklist

- [X] The code follows all style guidelines.
- [X] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [X] I have self-reviewed my changes and have done QA.