### PR TITLE
display seat info on timetable sidebar

### DIFF
--- a/src/lib/api/getSections.ts
+++ b/src/lib/api/getSections.ts
@@ -8,7 +8,7 @@ interface getSectionsProps {
 
 export const getSections = async ({ term, subject, code }: getSectionsProps): Promise<Section[]> => {
   const response = await fetch(
-    `${process.env.REACT_APP_API_URL ?? '/api'}/sections/${term}?subject=${subject}&code=${code}`
+    `${process.env.REACT_APP_API_URL ?? '/api'}/sections/${term}?subject=${subject}&code=${code}&v9=true`
   );
   return response.json();
 };

--- a/src/pages/scheduler/components/SchedulerSections.tsx
+++ b/src/pages/scheduler/components/SchedulerSections.tsx
@@ -191,22 +191,23 @@ export const Option = forwardRef<OptionsProps, 'div'>(function Option(
             position="sticky"
           />
         </HStack>
-        <VStack flexGrow={1} py="1.5">
+        <VStack w="100%" alignItems="left" spacing="2" py="1.5">
+          <Text as="strong">{sectionCode}</Text>
           {meetingTimes.map((m, key) => {
             return (
-              <VStack key={key} w="100%" alignItems={'left'} spacing={'0.5'}>
-                <Text as="strong">{sectionCode}</Text>
-                <HStack>
+              <Flex key={key} gap="1" flexDirection="row" flexWrap="wrap">
                   <HStack spacing={'1'}>
                     <CalendarIcon />
                     <Text>{m.days}</Text>
                   </HStack>
                   <Time time={m.time} />
-                </HStack>
                 <HStack spacing={'1'}>
                   <FaMapMarkerAlt />
                   <Location alwaysShort short={`${m.buildingAbbreviation} ${m.roomNumber}`} long={m.where} />
                 </HStack>
+              </Flex>
+            );
+          })}
                 {seats && (
                   <HStack>
                     <FaUser />
@@ -224,9 +225,6 @@ export const Option = forwardRef<OptionsProps, 'div'>(function Option(
                     </VStack>
                   </HStack>
                 )}
-              </VStack>
-            );
-          })}
         </VStack>
       </HStack>
     </Tooltip>

--- a/src/pages/scheduler/components/SchedulerSections.tsx
+++ b/src/pages/scheduler/components/SchedulerSections.tsx
@@ -187,16 +187,16 @@ export const Option = forwardRef<OptionsProps, 'div'>(
                     </Flex>
                   </Box>
                 )}
-                <Box w="20%" minW="20%">
+                <Box w="20%" minW="25%">
                   {m.time.split('-').map((time) => (
                     <Text key={time}>{time}</Text>
                   ))}
                 </Box>
-                <Box w="10%" minW="7.5%">
+                <Box w="12.5%" minW="10%">
                   {m.days}
                 </Box>
-                <Box w="40%">
-                  <Location short={`${m.buildingAbbreviation} ${m.roomNumber}`} long={m.where} />
+                <Box w="30%">
+                  <Location alwaysShort short={`${m.buildingAbbreviation} ${m.roomNumber}`} long={m.where} />
                 </Box>
               </HStack>
             ))}

--- a/src/pages/scheduler/components/SchedulerSections.tsx
+++ b/src/pages/scheduler/components/SchedulerSections.tsx
@@ -138,18 +138,22 @@ export interface OptionsProps {
   seats: Section['seats'];
 }
 
-const maxAdditionalNotesLength = 200;
-
 export const Option = forwardRef<OptionsProps, 'div'>(function Option(
   { meetingTimes, sectionCode, additionalNotes, seats }: OptionsProps,
   ref
 ): JSX.Element {
   const mode = useDarkMode();
 
-  const truncAdditionalNotes =
-    (additionalNotes?.length ?? 0) > maxAdditionalNotesLength
-      ? additionalNotes?.substring(0, maxAdditionalNotesLength).trim() + '…'
-      : additionalNotes;
+  additionalNotes = additionalNotes
+    ?.trim()
+    ?.replace(
+      /^For a description of this course, and to check for prerequisites and mutually exclusive \(MX\) courses, see the Calendar\./,
+      ''
+    )
+    ?.trim()
+    ?.replace(/^Section information text:/, '')
+    ?.trim()
+    ?.replace(/^(.{0,200}).*/, '$1…');
 
   const sectionFull = seats?.enrollment === seats?.maxEnrollment;
   const waitlistFull = seats?.waitCount === seats?.waitCapacity;
@@ -173,7 +177,7 @@ export const Option = forwardRef<OptionsProps, 'div'>(function Option(
   }
 
   return (
-    <Tooltip label={truncAdditionalNotes} isDisabled={!additionalNotes} placement="left">
+    <Tooltip label={additionalNotes} isDisabled={!additionalNotes} placement="left">
       <HStack
         as="label"
         px="3"

--- a/src/pages/scheduler/components/SchedulerSections.tsx
+++ b/src/pages/scheduler/components/SchedulerSections.tsx
@@ -180,7 +180,7 @@ export const Option = forwardRef<OptionsProps, 'div'>(function Option(
         my="0.5"
         fontSize="12px"
         borderTop={mode('light.background', 'dark.background')}
-        borderTopWidth="2"
+        borderTopWidth="medium"
         borderTopStyle="solid"
       >
         <HStack ref={ref}>
@@ -196,11 +196,11 @@ export const Option = forwardRef<OptionsProps, 'div'>(function Option(
           {meetingTimes.map((m, key) => {
             return (
               <Flex key={key} gap="1" flexDirection="row" flexWrap="wrap">
-                  <HStack spacing={'1'}>
-                    <CalendarIcon />
-                    <Text>{m.days}</Text>
-                  </HStack>
-                  <Time time={m.time} />
+                <HStack spacing={'1'}>
+                  <CalendarIcon />
+                  <Text>{m.days}</Text>
+                </HStack>
+                <Time time={m.time} />
                 <HStack spacing={'1'}>
                   <FaMapMarkerAlt />
                   <Location alwaysShort short={`${m.buildingAbbreviation} ${m.roomNumber}`} long={m.where} />
@@ -208,23 +208,23 @@ export const Option = forwardRef<OptionsProps, 'div'>(function Option(
               </Flex>
             );
           })}
-                {seats && (
-                  <HStack>
-                    <FaUser />
-                    <VStack spacing={'0.5'}>
-                      <Text>Seats</Text>
-                      <Badge as="b" colorScheme={sectionFull ? 'red' : 'green'}>
-                        {seats.enrollment}/{seats.maxEnrollment}
-                      </Badge>
-                    </VStack>
-                    <VStack spacing={'0.5'}>
-                      <Text>Waitlist</Text>
-                      <Badge as="b" colorScheme={waitlistFull ? 'red' : 'green'}>
-                        {seats.waitCount}/{seats.waitCapacity}
-                      </Badge>
-                    </VStack>
-                  </HStack>
-                )}
+          {seats && (
+            <HStack>
+              <FaUser />
+              <VStack spacing={'0.5'}>
+                <Text>Seats</Text>
+                <Badge as="b" colorScheme={sectionFull ? 'red' : 'green'}>
+                  {seats.enrollment}/{seats.maxEnrollment}
+                </Badge>
+              </VStack>
+              <VStack spacing={'0.5'}>
+                <Text>Waitlist</Text>
+                <Badge as="b" colorScheme={waitlistFull ? 'red' : 'green'}>
+                  {seats.waitCount}/{seats.waitCapacity}
+                </Badge>
+              </VStack>
+            </HStack>
+          )}
         </VStack>
       </HStack>
     </Tooltip>

--- a/src/pages/scheduler/components/SchedulerSections.tsx
+++ b/src/pages/scheduler/components/SchedulerSections.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 
+import { CalendarIcon, TimeIcon } from '@chakra-ui/icons';
 import { Radio, RadioGroup, Box, HStack, Text, VStack, Tooltip, forwardRef, Badge, Flex } from '@chakra-ui/react';
+import { FaMapMarkerAlt, FaUser } from 'react-icons/fa';
 
 import { MeetingTimes, Section } from 'lib/fetchers';
 import { useDarkMode } from 'lib/hooks/useDarkMode';
@@ -150,6 +152,24 @@ export const Option = forwardRef<OptionsProps, 'div'>(
     const sectionFull = seats?.enrollment === seats?.maxEnrollment;
     const waitlistFull = seats?.waitCount === seats?.waitCapacity;
 
+    function Time({ time }: { time: string }) {
+      const [start, end] = time.split('-');
+      return (
+        <HStack spacing={'1'}>
+          <TimeIcon />
+          <Flex flexDirection={'row'}>
+            <Text display={'inline-block'} whiteSpace={'nowrap'}>
+              {start}
+            </Text>
+            <Text>-</Text>
+            <Text display={'inline-block'} whiteSpace={'nowrap'}>
+              {end}
+            </Text>
+          </Flex>
+        </HStack>
+      );
+    }
+
     return (
       <Tooltip label={truncAdditionalNotes} isDisabled={!additionalNotes} placement="left">
         <HStack
@@ -168,38 +188,43 @@ export const Option = forwardRef<OptionsProps, 'div'>(
               // HACK: position: sticky needed to fix issue with button click jumping position on page
               position="sticky"
             />
-            <Text as="strong">{sectionCode}</Text>
           </HStack>
           <VStack flexGrow={1} py="1.5">
-            {meetingTimes.map((m, key) => (
-              <HStack key={key} w="100%" px="1">
-                {seats && (
-                  <Box w="20%" minW="10%">
-                    <Flex flexWrap={'wrap'} justify={'center'}>
-                      <Badge as="b" colorScheme={sectionFull ? 'red' : 'green'}>
-                        {seats.enrollment}/{seats.maxEnrollment}
-                      </Badge>
-                      {sectionFull && (
+            {meetingTimes.map((m, key) => {
+              return (
+                <VStack key={key} w="100%" alignItems={'left'} spacing={'0.5'}>
+                  <Text as="strong">{sectionCode}</Text>
+                  <HStack>
+                    <HStack spacing={'1'}>
+                      <CalendarIcon />
+                      <Text>{m.days}</Text>
+                    </HStack>
+                    <Time time={m.time} />
+                  </HStack>
+                  <HStack spacing={'1'}>
+                    <FaMapMarkerAlt />
+                    <Location alwaysShort short={`${m.buildingAbbreviation} ${m.roomNumber}`} long={m.where} />
+                  </HStack>
+                  {seats && (
+                    <HStack>
+                      <FaUser />
+                      <VStack spacing={'0.5'}>
+                        <Text>Seats</Text>
+                        <Badge as="b" colorScheme={sectionFull ? 'red' : 'green'}>
+                          {seats.enrollment}/{seats.maxEnrollment}
+                        </Badge>
+                      </VStack>
+                      <VStack spacing={'0.5'}>
+                        <Text>Waitlist</Text>
                         <Badge as="b" colorScheme={waitlistFull ? 'red' : 'green'}>
                           ({seats.waitCount}/{seats.waitCapacity})
                         </Badge>
-                      )}
-                    </Flex>
-                  </Box>
-                )}
-                <Box w="20%" minW="25%">
-                  {m.time.split('-').map((time) => (
-                    <Text key={time}>{time}</Text>
-                  ))}
-                </Box>
-                <Box w="12.5%" minW="10%">
-                  {m.days}
-                </Box>
-                <Box w="30%">
-                  <Location alwaysShort short={`${m.buildingAbbreviation} ${m.roomNumber}`} long={m.where} />
-                </Box>
-              </HStack>
-            ))}
+                      </VStack>
+                    </HStack>
+                  )}
+                </VStack>
+              );
+            })}
           </VStack>
         </HStack>
       </Tooltip>

--- a/src/pages/scheduler/components/SchedulerSections.tsx
+++ b/src/pages/scheduler/components/SchedulerSections.tsx
@@ -140,94 +140,96 @@ export interface OptionsProps {
 
 const maxAdditionalNotesLength = 200;
 
-export const Option = forwardRef<OptionsProps, 'div'>(
-  ({ meetingTimes, sectionCode, additionalNotes, seats }: OptionsProps, ref): JSX.Element => {
-    const mode = useDarkMode();
+export const Option = forwardRef<OptionsProps, 'div'>(function Option(
+  { meetingTimes, sectionCode, additionalNotes, seats }: OptionsProps,
+  ref
+): JSX.Element {
+  const mode = useDarkMode();
 
-    const truncAdditionalNotes =
-      (additionalNotes?.length ?? 0) > maxAdditionalNotesLength
-        ? additionalNotes?.substring(0, maxAdditionalNotesLength).trim() + '…'
-        : additionalNotes;
+  const truncAdditionalNotes =
+    (additionalNotes?.length ?? 0) > maxAdditionalNotesLength
+      ? additionalNotes?.substring(0, maxAdditionalNotesLength).trim() + '…'
+      : additionalNotes;
 
-    const sectionFull = seats?.enrollment === seats?.maxEnrollment;
-    const waitlistFull = seats?.waitCount === seats?.waitCapacity;
+  const sectionFull = seats?.enrollment === seats?.maxEnrollment;
+  const waitlistFull = seats?.waitCount === seats?.waitCapacity;
 
-    function Time({ time }: { time: string }) {
-      const [start, end] = time.split('-');
-      return (
-        <HStack spacing={'1'}>
-          <TimeIcon />
-          <Flex flexDirection={'row'}>
-            <Text display={'inline-block'} whiteSpace={'nowrap'}>
-              {start}
-            </Text>
-            <Text>-</Text>
-            <Text display={'inline-block'} whiteSpace={'nowrap'}>
-              {end}
-            </Text>
-          </Flex>
-        </HStack>
-      );
-    }
-
+  function Time({ time }: { time: string }) {
+    const [start, end] = time.split('-');
     return (
-      <Tooltip label={truncAdditionalNotes} isDisabled={!additionalNotes} placement="left">
-        <HStack
-          as="label"
-          px="3"
-          my="0.5"
-          fontSize="12px"
-          borderTop={mode('light.background', 'dark.background')}
-          borderTopWidth="2"
-          borderTopStyle="solid"
-        >
-          <HStack ref={ref}>
-            <Radio
-              value={sectionCode}
-              bgColor="white"
-              // HACK: position: sticky needed to fix issue with button click jumping position on page
-              position="sticky"
-            />
-          </HStack>
-          <VStack flexGrow={1} py="1.5">
-            {meetingTimes.map((m, key) => {
-              return (
-                <VStack key={key} w="100%" alignItems={'left'} spacing={'0.5'}>
-                  <Text as="strong">{sectionCode}</Text>
-                  <HStack>
-                    <HStack spacing={'1'}>
-                      <CalendarIcon />
-                      <Text>{m.days}</Text>
-                    </HStack>
-                    <Time time={m.time} />
-                  </HStack>
-                  <HStack spacing={'1'}>
-                    <FaMapMarkerAlt />
-                    <Location alwaysShort short={`${m.buildingAbbreviation} ${m.roomNumber}`} long={m.where} />
-                  </HStack>
-                  {seats && (
-                    <HStack>
-                      <FaUser />
-                      <VStack spacing={'0.5'}>
-                        <Text>Seats</Text>
-                        <Badge as="b" colorScheme={sectionFull ? 'red' : 'green'}>
-                          {seats.enrollment}/{seats.maxEnrollment}
-                        </Badge>
-                      </VStack>
-                      <VStack spacing={'0.5'}>
-                        <Text>Waitlist</Text>
-                        <Badge as="b" colorScheme={waitlistFull ? 'red' : 'green'}>
-                          ({seats.waitCount}/{seats.waitCapacity})
-                        </Badge>
-                      </VStack>
-                    </HStack>
-                  )}
-                </VStack>
-              );
-            })}
-          </VStack>
-        </HStack>
-      </Tooltip>
+      <HStack spacing={'1'}>
+        <TimeIcon />
+        <Flex flexDirection={'row'}>
+          <Text display={'inline-block'} whiteSpace={'nowrap'}>
+            {start}
+          </Text>
+          <Text>-</Text>
+          <Text display={'inline-block'} whiteSpace={'nowrap'}>
+            {end}
+          </Text>
+        </Flex>
+      </HStack>
     );
   }
-);
+
+  return (
+    <Tooltip label={truncAdditionalNotes} isDisabled={!additionalNotes} placement="left">
+      <HStack
+        as="label"
+        px="3"
+        my="0.5"
+        fontSize="12px"
+        borderTop={mode('light.background', 'dark.background')}
+        borderTopWidth="2"
+        borderTopStyle="solid"
+      >
+        <HStack ref={ref}>
+          <Radio
+            value={sectionCode}
+            bgColor="white"
+            // HACK: position: sticky needed to fix issue with button click jumping position on page
+            position="sticky"
+          />
+        </HStack>
+        <VStack flexGrow={1} py="1.5">
+          {meetingTimes.map((m, key) => {
+            return (
+              <VStack key={key} w="100%" alignItems={'left'} spacing={'0.5'}>
+                <Text as="strong">{sectionCode}</Text>
+                <HStack>
+                  <HStack spacing={'1'}>
+                    <CalendarIcon />
+                    <Text>{m.days}</Text>
+                  </HStack>
+                  <Time time={m.time} />
+                </HStack>
+                <HStack spacing={'1'}>
+                  <FaMapMarkerAlt />
+                  <Location alwaysShort short={`${m.buildingAbbreviation} ${m.roomNumber}`} long={m.where} />
+                </HStack>
+                {seats && (
+                  <HStack>
+                    <FaUser />
+                    <VStack spacing={'0.5'}>
+                      <Text>Seats</Text>
+                      <Badge as="b" colorScheme={sectionFull ? 'red' : 'green'}>
+                        {seats.enrollment}/{seats.maxEnrollment}
+                      </Badge>
+                    </VStack>
+                    <VStack spacing={'0.5'}>
+                      <Text>Waitlist</Text>
+                      <Badge as="b" colorScheme={waitlistFull ? 'red' : 'green'}>
+                        {seats.waitCount}/{seats.waitCapacity}
+                      </Badge>
+                    </VStack>
+                  </HStack>
+                )}
+              </VStack>
+            );
+          })}
+        </VStack>
+      </HStack>
+    </Tooltip>
+  );
+});
+// Option.displayName = 'Option';


### PR DESCRIPTION
# Description

This change displays seat info on the timetable page. I found this to be a usability improvement when creating a schedule after the registration date, as most sections had filled up but I had to tab back and forth to the Courses tab to see which ones were full.

## Screenshots

The timetable view on a full-sized 1080p monitor (new vs old):
### New
![image](https://user-images.githubusercontent.com/56709101/234714494-f5f68286-3099-4d95-a592-b3d659b2ab79.png)
### Old
![image](https://user-images.githubusercontent.com/56709101/234714771-98c2b831-4a07-4935-b019-3e16f9bd786d.png)

The timetable view on a scaled 1080p laptop display (new vs old):
### New
![image](https://user-images.githubusercontent.com/56709101/234714593-fbff1468-66ac-45ea-a0a2-9ea07f04fab5.png)
### Old
![image](https://user-images.githubusercontent.com/56709101/234715071-4882e3a0-81ff-49f3-9e2e-f101e2f4b72c.png)

## Checklist

- [x] The code follows all style guidelines.
- [x] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.

## General Comments

I'm not too happy with how the change squishes the rest of the columns on smaller devices. I'm open to suggestions on how to improve that, my current strategy was just to make every existing column smaller.

<!-- Optional - Add anything else you would like to add to the Pull Request -->
