### PR TITLE
Fix re-render loop caused by `useTerm`

### DIFF
--- a/src/lib/hooks/useTerm.ts
+++ b/src/lib/hooks/useTerm.ts
@@ -7,11 +7,9 @@ import useLocalStorage from './storage/useLocalStorage';
 
 export const useTerm = (): [Term, (term: string) => void] => {
   const { term: termParam } = useParams();
-  const defaultTerm = getCurrentTerm();
-  const [term, setTerm] = useLocalStorage<string>('user:term', defaultTerm) as [Term, (term: string) => void];
-
   // The URL parameter should override getCurrentTerm() and the stored term.
-  if (termParam) setTerm(termParam);
+  const defaultTerm = termParam || getCurrentTerm();
+  const [term, setTerm] = useLocalStorage<string>('user:term', defaultTerm) as [Term, (term: string) => void];
 
   return [term, setTerm];
 };

--- a/src/lib/hooks/useTerm.ts
+++ b/src/lib/hooks/useTerm.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { useParams } from 'react-router';
 
 import { Term } from 'lib/fetchers';
@@ -8,7 +10,7 @@ import useLocalStorage from './storage/useLocalStorage';
 export const useTerm = (): [Term, (term: string) => void] => {
   const { term: termParam } = useParams();
   // The URL parameter should override getCurrentTerm() and the stored term.
-  const defaultTerm = termParam || getCurrentTerm();
+  const defaultTerm = useMemo(() => termParam || getCurrentTerm(), [termParam]);
   const [term, setTerm] = useLocalStorage<string>('user:term', defaultTerm) as [Term, (term: string) => void];
 
   return [term, setTerm];


### PR DESCRIPTION
# Description

There was a re-render loop happening when the term was included in the URL parameter. Aomi pointed out that the issue was caused by the fact that the hook would use its own `setTerm` function to update the term when the URL parameter was there. I updated the logic so it now would use the URL parameter as the 'first priority' default value instead of setting it after the fact.

## Checklist

- [x] The code follows all style guidelines.
- [x] The code passes all required tests.
- [x] The code is documented.
- [ ] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.
