### PR TITLE
Change banner to be clearer about winter terms

### DIFF
--- a/src/common/header/containers/HeaderContainer.tsx
+++ b/src/common/header/containers/HeaderContainer.tsx
@@ -68,9 +68,13 @@ export function HeaderContainer({ onSearchChange }: HeaderProps): JSX.Element {
         <Text>
           📅 The{' '}
           <Text as={Link} to="/calendar/202309" textDecoration="underline">
-            Winter 2023
+            Fall 2023
           </Text>{' '}
-          calendar is now available. Happy scheduling!
+          and{' '}
+          <Text as={Link} to="/calendar/202401" textDecoration="underline">
+            Spring 2024
+          </Text>{' '}
+          calendars are now available. Happy scheduling!
         </Text>,
       ];
   return (

--- a/src/lib/hooks/useTerm.ts
+++ b/src/lib/hooks/useTerm.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { useParams } from 'react-router';
 
@@ -12,6 +12,12 @@ export const useTerm = (): [Term, (term: string) => void] => {
   // The URL parameter should override getCurrentTerm() and the stored term.
   const defaultTerm = useMemo(() => termParam || getCurrentTerm(), [termParam]);
   const [term, setTerm] = useLocalStorage<string>('user:term', defaultTerm) as [Term, (term: string) => void];
+
+  useEffect(() => {
+    if (termParam && termParam !== term) {
+      setTerm(termParam);
+    }
+  }, [termParam, term, setTerm]);
 
   return [term, setTerm];
 };


### PR DESCRIPTION
# Description

Changes "Winter 2023 calendar is now available", with link leading to Fall 2023 to "The Fall 2023 and Spring 2024 calendars are now available", with links to each individual winter term

This also fixes an issue that clicking on banner items (i.e. changing the URL term param) doesn't actually update the selected term.

Closes #475 

## Screenshots

### Before
<img width="1039" alt="image" src="https://github.com/VikeLabs/courseup/assets/50898635/7418f94d-9fa3-49b7-8238-7c2615753bb7">

### After
<img width="1034" alt="image" src="https://github.com/VikeLabs/courseup/assets/50898635/2fbaf713-4c9b-44ed-a0ac-bcb23459d527">

## Checklist

- [x] The code follows all style guidelines.
- [x] The code passes all required tests.
- [x] The code is documented.
- [ ] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.
