### PR TITLE
Moves term selector

### DIFF
--- a/src/common/header/components/TermSelect.tsx
+++ b/src/common/header/components/TermSelect.tsx
@@ -44,13 +44,19 @@ export function TermSelect(): JSX.Element {
 
   let colorMap: { [key: string]: string } = {};
   colorMap['09'] = mode('green.500', 'green.300');
-  colorMap['01'] = mode('blue.500', 'blue.300');
+  colorMap['09'] = mode('blue.500', 'blue.300');
   colorMap['05'] = mode('yellow.500', 'yellow.300');
 
   // TODO: A "bug" in Firefox for macOS is preventing the `option` components
   // from inheriting the `Select` background color this leads to illegible text in the options.
   return (
-    <Select borderColor={colorMap[selectedTerm.slice(-2)]} value={selectedTerm} onChange={onChange} minW="150px">
+    <Select
+      borderColor={colorMap[selectedTerm.slice(-2)]}
+      value={selectedTerm}
+      onChange={onChange}
+      minW="150px"
+      borderWidth="2px"
+    >
       {terms.map((term, i) => {
         return (
           <option key={i} value={term}>

--- a/src/common/header/components/TermSelect.tsx
+++ b/src/common/header/components/TermSelect.tsx
@@ -42,10 +42,15 @@ export function TermSelect(): JSX.Element {
     }
   };
 
+  let colorMap: { [key: string]: string } = {};
+  colorMap['09'] = mode('green.500', 'green.300');
+  colorMap['01'] = mode('blue.500', 'blue.300');
+  colorMap['05'] = mode('yellow.500', 'yellow.300');
+
   // TODO: A "bug" in Firefox for macOS is preventing the `option` components
-  // from inheriting the `Select` background color this leads to eligible text in the options.
+  // from inheriting the `Select` background color this leads to illegible text in the options.
   return (
-    <Select borderColor={mode('green.500', 'green.300')} value={selectedTerm} onChange={onChange} minW="150px">
+    <Select borderColor={colorMap[selectedTerm.slice(-2)]} value={selectedTerm} onChange={onChange} minW="150px">
       {terms.map((term, i) => {
         return (
           <option key={i} value={term}>

--- a/src/common/header/components/TermSelect.tsx
+++ b/src/common/header/components/TermSelect.tsx
@@ -56,6 +56,7 @@ export function TermSelect(): JSX.Element {
       onChange={onChange}
       minW="150px"
       borderWidth="2px"
+      _hover={{ bgColor: colorMap[selectedTerm.slice(-2)] }}
     >
       {terms.map((term, i) => {
         return (

--- a/src/common/header/components/TermSelect.tsx
+++ b/src/common/header/components/TermSelect.tsx
@@ -57,6 +57,7 @@ export function TermSelect(): JSX.Element {
       minW="150px"
       borderWidth="2px"
       _hover={{ bgColor: colorMap[selectedTerm.slice(-2)] }}
+      _focus={{ borderColor: colorMap[selectedTerm.slice(-2)] }}
     >
       {terms.map((term, i) => {
         return (

--- a/src/common/header/components/TermSelect.tsx
+++ b/src/common/header/components/TermSelect.tsx
@@ -44,7 +44,7 @@ export function TermSelect(): JSX.Element {
 
   let colorMap: { [key: string]: string } = {};
   colorMap['09'] = mode('green.500', 'green.300');
-  colorMap['09'] = mode('blue.500', 'blue.300');
+  colorMap['01'] = mode('blue.500', 'blue.300');
   colorMap['05'] = mode('yellow.500', 'yellow.300');
 
   // TODO: A "bug" in Firefox for macOS is preventing the `option` components

--- a/src/common/header/components/TermSelect.tsx
+++ b/src/common/header/components/TermSelect.tsx
@@ -43,9 +43,9 @@ export function TermSelect(): JSX.Element {
   };
 
   let colorMap: { [key: string]: string } = {};
-  colorMap['09'] = mode('green.500', 'green.300');
-  colorMap['01'] = mode('blue.500', 'blue.300');
-  colorMap['05'] = mode('yellow.500', 'yellow.300');
+  colorMap['09'] = mode('green.300', 'green.500');
+  colorMap['01'] = mode('blue.300', 'blue.500');
+  colorMap['05'] = mode('yellow.300', 'yellow.500');
 
   // TODO: A "bug" in Firefox for macOS is preventing the `option` components
   // from inheriting the `Select` background color this leads to illegible text in the options.

--- a/src/common/header/containers/HeaderContainer.tsx
+++ b/src/common/header/containers/HeaderContainer.tsx
@@ -104,10 +104,12 @@ export function HeaderContainer({ onSearchChange }: HeaderProps): JSX.Element {
               </Text>
             </LinkBox>
             <Search onChange={onSearchChange} />
-            <NavButtons />
-            <Spacer />
             <HStack>
               <TermSelect />
+            </HStack>
+            <Spacer />
+            <NavButtons />
+            <HStack>
               <MiscHeaderButtons />
             </HStack>
           </HStack>


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change(s) and which issue is being fixed. Please provide as much detail as possible. -->
Moves the term selector closer to the search bar for better UX. Also conditionally applies colors to selector border based on term. 

<!-- Replace `XX` with the concerning issue number. -->
Closes #372

## Screenshots
<!-- Delete this section if changes do not require screenshots -->

<!-- Include any relevant screenshots or gifs to all frontend changes when applicable. -->

### Before
<!-- Add before screenshots when applicable. -->
<img width="1507" alt="Screenshot 2023-07-26 at 7 28 25 PM" src="https://github.com/VikeLabs/courseup/assets/77510623/f24694dd-b801-4470-ac0d-0c1d1aa4bbf6">

### After
<!-- Add after screenshots when applicable. -->
<img width="758" alt="Screenshot 2023-07-26 at 7 28 47 PM" src="https://github.com/VikeLabs/courseup/assets/77510623/3d14359f-344d-409a-b786-7dad80883e10">
<img width="757" alt="Screenshot 2023-07-26 at 7 28 53 PM" src="https://github.com/VikeLabs/courseup/assets/77510623/37e53f6f-bdea-421b-9d0f-a260a7eb856d">
<img width="757" alt="Screenshot 2023-07-26 at 7 29 02 PM" src="https://github.com/VikeLabs/courseup/assets/77510623/6b1c39d2-48cf-460a-afc5-dd88454bdd8d">


## Checklist

- [x] The code follows all style guidelines.
- [x] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [x] I have self-reviewed my changes and have done QA.

## General Comments

<!-- Optional - Add anything else you would like to add to the Pull Request -->
