### PR TITLE
Stop using v9 data (banner)

### DIFF
--- a/src/pages/calendar/containers/Section.tsx
+++ b/src/pages/calendar/containers/Section.tsx
@@ -39,7 +39,7 @@ export function SectionsContainer({ term, subject, code }: SectionsContainerProp
     data: sections,
     loading,
     error: sectionsError,
-  } = useSections({ term, queryParams: { subject, code, v9: true } });
+  } = useSections({ term, queryParams: { subject, code, v9: false } });
   const mode = useDarkMode();
 
   const seats = useMemo(() => {

--- a/src/pages/registration/containers/CourseContainer.tsx
+++ b/src/pages/registration/containers/CourseContainer.tsx
@@ -31,7 +31,7 @@ export function CourseContainer({ course }: Props) {
 
   const { data: sections, loading } = useSections({
     term: termType,
-    queryParams: { subject: course.subject, code: course.code, v9: true },
+    queryParams: { subject: course.subject, code: course.code, v9: false },
   });
   const seats = useMemo(() => {
     return sections


### PR DESCRIPTION
# Description

Disable v9 flag to stop using banner data and use scraper instead. Tested locally and seemed to work properly with the data already in prod db

<!-- Replace `XX` with the concerning issue number. -->
Closes #510 

## Screenshots
<!-- Delete this section if changes do not require screenshots -->

<!-- Include any relevant screenshots or gifs to all frontend changes when applicable. -->

### Before
<!-- Add before screenshots when applicable. -->
<img width="763" alt="image" src="https://github.com/VikeLabs/courseup/assets/50898635/e7897eed-a6df-45d4-a4f9-e310fd8b0d27">

### After
<img width="753" alt="image" src="https://github.com/VikeLabs/courseup/assets/50898635/845238c1-03c0-43ec-9d2e-e9ca745132c9">

## Checklist

- [ ] The code follows all style guidelines.
- [ ] The code passes all required tests.
- [ ] The code is documented.
- [ ] The code includes tests.
- [ ] I have self-reviewed my changes and have done QA.
